### PR TITLE
Remove unneeded annotations

### DIFF
--- a/app/travel_processor/capabilities.cds
+++ b/app/travel_processor/capabilities.cds
@@ -2,14 +2,3 @@ using {TravelService} from '../../srv/travel-service';
 
 annotate TravelService.Travel with @odata.draft.enabled;
 annotate TravelService.Travel with @Common.SemanticKey: [TravelID];
-
-annotate TravelService with @(
-  Aggregation.ApplySupported.Rollup: #None,
-  Aggregation.ApplySupported.Transformations: [
-    'aggregate',
-    'groupby',
-    'filter'
-  ],
-  Common.ApplyMultiUnitBehaviorForSortingAndFiltering: true,
-  Org.OData.Capabilities.V1.BatchSupport.ReferencesAcrossChangeSetsSupported: true
-);


### PR DESCRIPTION
These lead to failures in runtime when upgrading to UI5 1.92-snapshot