### PR TITLE
fix button calculation on draft edit

### DIFF
--- a/app/travel_processor/ui5-deploy.yaml
+++ b/app/travel_processor/ui5-deploy.yaml
@@ -3,7 +3,7 @@ specVersion: "1.0"
 metadata:
   name: sap.fe.cap.travel
 type: application
-ui5Version:
+ui5Version: 1.92.1
 ui5Theme: sap_fiori_3
 resources:
   configuration:

--- a/app/travel_processor/ui5.yaml
+++ b/app/travel_processor/ui5.yaml
@@ -6,7 +6,7 @@ metadata:
 
 framework:
   name: SAPUI5
-  version: 1.89.0
+  version: 1.92.1
   libraries:
     - name: sap.ui.core
     - name: sap.fe.templates

--- a/app/travel_processor/webapp/test/integration/OpaJourney.js
+++ b/app/travel_processor/webapp/test/integration/OpaJourney.js
@@ -24,7 +24,7 @@ sap.ui.define(["sap/ui/test/opaQunit"], function (opaTest) {
       opaTest(
         "#2: Object Page: Check Object Page loads",
         function (Given, When, Then) {
-          When.onTheMainPage.onTable().iPressRow({ TravelID: "4,133" });
+          When.onTheMainPage.onTable().iPressRow({ TravelID: "4133" });
           Then.onTheDetailPage.iSeeThisPage();
 
           When.iNavigateBack();
@@ -126,7 +126,7 @@ sap.ui.define(["sap/ui/test/opaQunit"], function (opaTest) {
             );
 
           // select first row
-          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4,132" });
+          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4132" });
 
           // Check that bound action is now active after selection
           Then.onTheMainPage
@@ -139,7 +139,7 @@ sap.ui.define(["sap/ui/test/opaQunit"], function (opaTest) {
           // check that "Travel status" is Open
           Then.onTheMainPage
             .onTable()
-            .iCheckRows({ TravelID: "4,132", "Travel Status": "Open" }, 1);
+            .iCheckRows({ TravelID: "4132", "Travel Status": "Open" }, 1);
 
           // trigger action
           When.onTheMainPage.onTable().iExecuteAction({
@@ -150,18 +150,18 @@ sap.ui.define(["sap/ui/test/opaQunit"], function (opaTest) {
           // check that "Travel status" is now Accepted
           Then.onTheMainPage
             .onTable()
-            .iCheckRows({ TravelID: "4,132", "Travel Status": "Accepted" }, 1);
+            .iCheckRows({ TravelID: "4132", "Travel Status": "Accepted" }, 1);
 
           // unselect first row
-          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4,132" });
+          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4132" });
 
           // select 2nd row
-          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4,131" });
+          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4131" });
 
           // check that "Travel status" is Open
           Then.onTheMainPage
             .onTable()
-            .iCheckRows({ TravelID: "4,131", "Travel Status": "Open" }, 1);
+            .iCheckRows({ TravelID: "4131", "Travel Status": "Open" }, 1);
 
           // trigger action
           When.onTheMainPage.onTable().iExecuteAction({
@@ -172,10 +172,10 @@ sap.ui.define(["sap/ui/test/opaQunit"], function (opaTest) {
           // check that "Travel status" is Open
           Then.onTheMainPage
             .onTable()
-            .iCheckRows({ TravelID: "4,131", "Travel Status": "Canceled" }, 1);
+            .iCheckRows({ TravelID: "4131", "Travel Status": "Canceled" }, 1);
 
           // unselect 2nd row
-          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4,131" });
+          Given.onTheMainPage.onTable().iSelectRows({ TravelID: "4131" });
 
           Then.onTheMainPage.iSeeThisPage();
         }

--- a/srv/travel-service.js
+++ b/srv/travel-service.js
@@ -12,12 +12,14 @@ init() {
   /**
    * Fill in virtual elements to control status of UI elements.
    */
-  this.after ('each', 'Travel', any => {
-    const { code: status } = any.TravelStatus || {}
+  const _calculateButtonAvailability = any => {
+    const status = any.TravelStatus && any.TravelStatus.code || any.TravelStatus_code
     any.acceptEnabled = status !== 'A'
     any.rejectEnabled = status !== 'X'
     any.deductDiscountEnabled = status !== 'A'
-  })
+  }
+  this.after ('each', 'Travel', _calculateButtonAvailability)
+  this.after ('EDIT', 'Travel', _calculateButtonAvailability)
 
 
   /**


### PR DESCRIPTION
When clicking on the "Edit" button on the UI, the buttons are not greyed out.

Reason is that our handler was only registered for "READ" events so far.

Unfortunately, we would also need to change the implementation of the handler as the query options ($select and $expand) for actions are evaluated in the protocol layer and therefore the format of the data in the after-handler is flat.

@danjoa I don't like that but that is the only way I can think of for now.

Maybe FE sent an additional GET request before or it has never worked before.

Alternatively, we could annotate a side effect to trigger the additional GET request.