### PR TITLE
Fix deductDiscountEnabled

### DIFF
--- a/app/travel_processor/field-control.cds
+++ b/app/travel_processor/field-control.cds
@@ -9,10 +9,9 @@ annotate cds.UUID with @Core.Computed  @odata.Type : 'Edm.String';
 
 // Add fields to control enablement of action buttons on UI
 extend projection TravelService.Travel with {
-  // REVISIT: shall be improved by omitting "null as"
-  virtual null as acceptEnabled         : Boolean @UI.Hidden,
-  virtual null as rejectEnabled         : Boolean @UI.Hidden,
-  virtual null as deductDiscountEnabled : Boolean @UI.Hidden,
+  CASE when TravelStatus.code = 'A' then false else true end as acceptEnabled : Boolean @UI.Hidden,
+  CASE when TravelStatus.code = 'X' then false else true end as rejectEnabled : Boolean @UI.Hidden,
+  CASE when TravelStatus.code = 'O' then true else false end as deductDiscountEnabled : Boolean @UI.Hidden,
 }
 
 annotate TravelService.Travel with @(Common.SideEffects: {

--- a/app/travel_processor/field-control.cds
+++ b/app/travel_processor/field-control.cds
@@ -30,7 +30,8 @@ annotate TravelService.Travel with @(Common.SideEffects: {
     Common.SideEffects.TargetProperties : [
       'in/TravelStatus_code',
       'in/acceptEnabled',
-      'in/rejectEnabled'
+      'in/rejectEnabled',
+      'in/deductDiscountEnabled'
     ],
   );
   acceptTravel @(
@@ -38,12 +39,12 @@ annotate TravelService.Travel with @(Common.SideEffects: {
     Common.SideEffects.TargetProperties : [
       'in/TravelStatus_code',
       'in/acceptEnabled',
-      'in/rejectEnabled'
+      'in/rejectEnabled',
+      'in/deductDiscountEnabled'
     ],
   );
   deductDiscount @(
     Core.OperationAvailable : in.deductDiscountEnabled,
-    Common.SideEffects.TargetProperties : ['in/deductDiscountEnabled'],
   );
 }
 

--- a/srv/travel-service.js
+++ b/srv/travel-service.js
@@ -10,19 +10,6 @@ init() {
 
 
   /**
-   * Fill in virtual elements to control status of UI elements.
-   */
-  const _calculateButtonAvailability = any => {
-    const status = any.TravelStatus && any.TravelStatus.code || any.TravelStatus_code
-    any.acceptEnabled = status !== 'A'
-    any.rejectEnabled = status !== 'X'
-    any.deductDiscountEnabled = status === 'O' || status === undefined
-  }
-  this.after ('each', 'Travel', _calculateButtonAvailability)
-  this.after ('EDIT', 'Travel', _calculateButtonAvailability)
-
-
-  /**
    * Fill in primary keys for new Travels.
    * Note: In contrast to Bookings and BookingSupplements that has to happen
    * upon SAVE, as multiple users could create new Travels concurrently.

--- a/srv/travel-service.js
+++ b/srv/travel-service.js
@@ -16,7 +16,7 @@ init() {
     const status = any.TravelStatus && any.TravelStatus.code || any.TravelStatus_code
     any.acceptEnabled = status !== 'A'
     any.rejectEnabled = status !== 'X'
-    any.deductDiscountEnabled = status === 'O'
+    any.deductDiscountEnabled = status === 'O' || status === undefined
   }
   this.after ('each', 'Travel', _calculateButtonAvailability)
   this.after ('EDIT', 'Travel', _calculateButtonAvailability)


### PR DESCRIPTION
Fixes this UI glitch:

1. Open any travel entry in Object Page
2. Do _Deduct Discount_ once
3. → _Deduct Discount_ button is erroneously disabled now
4. Leave to list page and re-enter Object Page
5. → _Deduct Discount_ button is correctly enabled now

This fix is not a nice one though → we should calculate there properties in the client, not in server