### PR TITLE
Remove SearchSupported property from value list annotations

### DIFF
--- a/app/travel_processor/value-helps.cds
+++ b/app/travel_processor/value-helps.cds
@@ -21,8 +21,7 @@ annotate my.Travel {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'PhoneNumber'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'EMailAddress'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'WebAddress'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   to_Customer @Common.ValueList: {
@@ -39,8 +38,7 @@ annotate my.Travel {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CountryCode_code'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'PhoneNumber'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'EMailAddress'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   CurrencyCode @Common.ValueList: {
@@ -52,8 +50,7 @@ annotate my.Travel {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'descr'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'symbol'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'minor'}
-    ],
-    SearchSupported : true
+    ]
   };
 
 }
@@ -77,8 +74,7 @@ annotate my.Booking {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CountryCode_code'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'PhoneNumber'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'EMailAddress'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   to_Carrier @Common.ValueList: {
@@ -88,8 +84,7 @@ annotate my.Booking {
       {$Type: 'Common.ValueListParameterInOut', LocalDataProperty: to_Carrier_AirlineID, ValueListProperty: 'AirlineID'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CurrencyCode_code'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   ConnectionID @Common.ValueList: {
@@ -106,7 +101,6 @@ annotate my.Booking {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'MaximumSeats'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'OccupiedSeats'}
     ],
-    SearchSupported : true,
     PresentationVariantQualifier: 'SortOrderPV'  // use presentation variant to sort by FlightDate desc
   };
 
@@ -123,8 +117,7 @@ annotate my.Booking {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'PlaneType'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'MaximumSeats'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'OccupiedSeats'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   CurrencyCode @Common.ValueList: {
@@ -136,8 +129,7 @@ annotate my.Booking {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'descr'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'symbol'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'minor'}
-    ],
-    SearchSupported : true
+    ]
   };
 
 }
@@ -153,8 +145,7 @@ annotate my.BookingSupplement {
     {$Type: 'Common.ValueListParameterInOut', LocalDataProperty: Price,        ValueListProperty: 'Price'},
     {$Type: 'Common.ValueListParameterInOut', LocalDataProperty: CurrencyCode_code, ValueListProperty: 'CurrencyCode_code'},
     {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Description'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   CurrencyCode @Common.ValueList: {
@@ -166,8 +157,7 @@ annotate my.BookingSupplement {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'descr'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'symbol'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'minor'}
-    ],
-    SearchSupported : true
+    ]
   };
 }
 
@@ -181,8 +171,7 @@ annotate my.Flight {
       {$Type: 'Common.ValueListParameterInOut', LocalDataProperty: AirlineID, ValueListProperty: 'AirlineID'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CurrencyCode'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   ConnectionID @Common.ValueList: {
@@ -198,8 +187,7 @@ annotate my.Flight {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'ArrivalTime'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Distance'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'DistanceUnit'}
-    ],
-    SearchSupported : true
+    ]
   };
 
 }
@@ -215,8 +203,7 @@ annotate my.FlightConnection {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'AirlineID'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CurrencyCode'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   DepartureAirport @Common.ValueList: {
@@ -228,8 +215,7 @@ annotate my.FlightConnection {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'City'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CountryCode'}
-    ],
-    SearchSupported : true
+    ]
   };
 
   DestinationAirport @Common.ValueList: {
@@ -241,8 +227,7 @@ annotate my.FlightConnection {
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'Name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'City'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty: 'CountryCode'}
-    ],
-    SearchSupported : true
+    ]
   };
 
 }
@@ -257,8 +242,7 @@ annotate my.Passenger {
       {$Type: 'Common.ValueListParameterInOut',       LocalDataProperty : CountryCode_code, ValueListProperty : 'code'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty : 'name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty : 'descr'}
-    ],
-    SearchSupported : true
+    ]
   };
 
 }
@@ -273,8 +257,7 @@ annotate my.TravelAgency {
       {$Type: 'Common.ValueListParameterInOut',       LocalDataProperty: CountryCode_code, ValueListProperty: 'code'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty : 'name'},
       {$Type: 'Common.ValueListParameterDisplayOnly', ValueListProperty : 'descr'}
-    ],
-    SearchSupported : true
+    ]
   };
 
 }


### PR DESCRIPTION
The combination of ValueListFixedValues and SearchSupported is not
supported by the UI5 OData Model. VH breaks if both would be defined at the same time.
As entity searchability defaults to true anyways if SearchSupported property is not defined,
it can be omitted.