### PR TITLE
Remove unnecessary and wrong "Visualizations"

### DIFF
--- a/app/travel_processor/layouts.cds
+++ b/app/travel_processor/layouts.cds
@@ -191,7 +191,6 @@ annotate TravelService.BookingSupplement with @UI : {
 
 annotate TravelService.Flight with @UI : {
   PresentationVariant#SortOrderPV : {    // used in the value help for ConnectionId in Bookings
-    Visualizations : ['@UI.LineItem'],
     SortOrder      : [{
       Property   : FlightDate,
       Descending : true


### PR DESCRIPTION
Annotation PresentationVariant for entity Flight contained
attribute Visualizations which was unnecessary and wrong, as it pointed to
a non-existing LineItems annotation.
Was introduced probably by copy&paste.

Signed-off-by: Steffen Weinstock <steffen.weinstock@sap.com>