### PR TITLE
Terminate the CAP server process when tests are finished

### DIFF
--- a/app/travel_processor/karma/cap-server.js
+++ b/app/travel_processor/karma/cap-server.js
@@ -50,14 +50,14 @@ async function java() {
     const started = data.match(/started on port\(s\): (?<port>\d+)/);
     if (started) return new URL(`http://localhost:${started.groups.port}`);
   };
-  const serverUrl = await spawnServer(
+  const [serverUrl, pid] = await spawnServer(
     "mvn",
     ["spring-boot:run", "-B", "-Dserver.port=0"],
     "../../srv",
     isReady
   );
 
-  return createKarmaMiddleware(serverUrl, { user: "admin", password: "admin" });
+  return createKarmaMiddleware(serverUrl, pid, { user: "admin", password: "admin" });
 }
 
 async function node() {

--- a/app/travel_processor/package-lock.json
+++ b/app/travel_processor/package-lock.json
@@ -16,6 +16,7 @@
         "karma-ui5": "^2.4.0",
         "puppeteer": "^13.1.1",
         "qunit": "^2.17.2",
+        "tree-kill": "^1.2.2",
         "ui5-middleware-http-proxy": "^2.0.0",
         "ui5-task-zipper": "^0.4.7"
       },
@@ -10231,6 +10232,15 @@
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
@@ -19999,6 +20009,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
     },
     "treeify": {

--- a/app/travel_processor/package.json
+++ b/app/travel_processor/package.json
@@ -29,6 +29,7 @@
     "karma-ui5": "^2.4.0",
     "puppeteer": "^13.1.1",
     "qunit": "^2.17.2",
+    "tree-kill": "^1.2.2",
     "ui5-middleware-http-proxy": "^2.0.0",
     "ui5-task-zipper": "^0.4.7"
   },


### PR DESCRIPTION
Symptom: After running the karma test, the spawned CAP process is not terminated and blocks the assigned port.

Cause: In Linux asynchronous processes are not terminated when the parent process terminates.

Solution: The karma event emitter is injected into the cap-server middle-ware. The middle-ware registers a callback on a event that is triggered after all tests are done. In the callback of this event the CAP process is killed with npm library tree-kill. This is necessary when other npm scripts are referenced when starting the server as they spawn their own processes.

Comment: I'm not sure if this is the perfect event but in my case it works.