### PR TITLE
Fault-tolerant test execution

### DIFF
--- a/app/travel_processor/karma/cap-server.js
+++ b/app/travel_processor/karma/cap-server.js
@@ -5,6 +5,7 @@ function spawnServer(cmd, args, cwd, fnIsReady) {
   return new Promise((resolve, reject) => {
     const proc = spawn(cmd, args, {
       cwd,
+      env: Object.assign({PORT:0}, process.env),
       stdio: ["ignore", "pipe", "inherit"],
     });
 
@@ -16,8 +17,12 @@ function spawnServer(cmd, args, cwd, fnIsReady) {
       }
     };
 
+
     proc.on("close", reject);
     proc.stdout.on("data", checkServerReady);
+
+    // clean up sub process
+    process.on('exit', ()=> { if (proc)  proc.kill(); } )
   });
 }
 


### PR DESCRIPTION
- Kill sub process after test (no more zombie processes)
- Start Node process on ephemeral port, much like with Java (no more port conflicts)