### PR TITLE
update ppiper/cf-cli version

### DIFF
--- a/.github/actions/cf-deploy/Dockerfile
+++ b/.github/actions/cf-deploy/Dockerfile
@@ -1,10 +1,8 @@
-FROM ppiper/cf-cli:v10
+FROM ppiper/cf-cli:v11
 
 # needed for cf to find its config
 # (GH resets HOME to /github/workspace)
 ENV CF_HOME=$HOME
-
-RUN cf install-plugin -r CF-Community "html5-plugin" -f
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The installaiton of the html5-plugin module can be removed as since version 11 this is included in the upstream project. See: [Adding html5 plugin #47](https://github.com/SAP/devops-docker-cf-cli/pull/47).