### PR TITLE
Java: Improve serving of UIs from Spring Boot

### DIFF
--- a/srv/src/main/java/com/sap/cap/sflight/ui/RedirectFilter.java
+++ b/srv/src/main/java/com/sap/cap/sflight/ui/RedirectFilter.java
@@ -1,0 +1,48 @@
+package com.sap.cap.sflight.ui;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * Redirects calls on relative paths coming from the Fiori apps in local development to the correct service endpoints.
+ * In cloud deployments this is not needed, as paths are managed differently by HTML5 apps repo & approuter.
+ */
+@Component
+@Profile("!cloud")
+public class RedirectFilter extends GenericFilterBean {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        String[] uiServicePaths = {
+            "/travel_processor/webapp/processor",
+            "/travel_analytics/webapp/analytics"
+        };
+
+        String path = req.getRequestURI();
+        for (String uiServicePath : uiServicePaths) {
+            if (path.startsWith(uiServicePath)) {
+                res.resetBuffer();
+                res.setStatus(308);
+                res.setHeader("Location", path.substring(uiServicePath.lastIndexOf('/')));
+                res.flushBuffer();
+                return;
+            }
+        }
+
+        chain.doFilter(req, res);
+    }
+
+}

--- a/srv/src/main/java/com/sap/cap/sflight/ui/UiIndexContentProviderFactory.java
+++ b/srv/src/main/java/com/sap/cap/sflight/ui/UiIndexContentProviderFactory.java
@@ -1,0 +1,51 @@
+package com.sap.cap.sflight.ui;
+
+import java.io.PrintWriter;
+
+import com.sap.cds.adapter.IndexContentProvider;
+import com.sap.cds.adapter.IndexContentProviderFactory;
+
+/**
+ * Explicitly adds links to UI resources provided by this application to the index page
+ */
+public class UiIndexContentProviderFactory implements IndexContentProviderFactory {
+
+	@Override
+	public IndexContentProvider create() {
+		return new UiIndexContentProvider();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	private static class UiIndexContentProvider implements IndexContentProvider {
+
+		private static final String ENDPOINT_START = "" +
+		"                <ul>\n";
+
+		private static final String ENDPOINT = "" +
+		"                    <li>\n" +
+		"                        <a href=\"%s\">%s</a>\n" +
+		"                    </li>\n";
+
+		private static final String ENDPOINT_END = "" +
+		"                </ul>\n";
+
+		@Override
+		public String getSectionTitle() {
+			return "UI endpoints";
+		}
+
+		@Override
+		public void writeContent(PrintWriter writer, String contextPath) {
+			writer.print(ENDPOINT_START);
+			writer.printf(ENDPOINT, contextPath + "/travel_processor/webapp/index.html", "Travel Processor UI");
+			writer.printf(ENDPOINT, contextPath + "/travel_analytics/webapp/index.html", "Travel Analytics UI");
+			writer.print(ENDPOINT_END);
+		}
+
+	}
+
+}

--- a/srv/src/main/resources/META-INF/services/com.sap.cds.adapter.IndexContentProviderFactory
+++ b/srv/src/main/resources/META-INF/services/com.sap.cds.adapter.IndexContentProviderFactory
@@ -1,0 +1,1 @@
+com.sap.cap.sflight.ui.UiIndexContentProviderFactory


### PR DESCRIPTION
- Links to UIs are now included on the index page for better discoverability
- Travel Processor UI path to processor service is now properly redirected on server-side to the processor service at /processor.