### PR TITLE
Pin to UI5 1.110.1

### DIFF
--- a/app/travel_analytics/webapp/index.html
+++ b/app/travel_analytics/webapp/index.html
@@ -16,7 +16,7 @@
     </style>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.110.1/resources/sap-ui-core.js"
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
       data-sap-ui-resourceroots='{ "sap.fe.cap.travel_analytics": "./" }'

--- a/app/travel_processor/webapp/index.html
+++ b/app/travel_processor/webapp/index.html
@@ -16,7 +16,7 @@
     </style>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.110.1/resources/sap-ui-core.js"
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
       data-sap-ui-resourceroots='{ "sap.fe.cap.travel": "." }'


### PR DESCRIPTION
There is a regression in UI5 1.111 that breaks the delete button enablement on the "Booking" object page. This change pins the UI5 version to the last known good one until there is a patch available