### PR TITLE
use version number for dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "passport": "^0.6.0"
       },
       "devDependencies": {
-        "@sap/ux-specification": "UI5-1.108",
+        "@sap/ux-specification": "1.108.1",
         "axios": "^1",
         "chai": "^4.3.0",
         "chai-as-promised": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "passport": "^0.6.0"
   },
   "devDependencies": {
-    "@sap/ux-specification": "UI5-1.108",
+    "@sap/ux-specification": "1.108.1",
     "axios": "^1",
     "chai": "^4.3.0",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
Not sure why but Kyma Deployment fails with the below error if we use tag instead of version:

```bash
node[28]: ../src/module_wrap.cc:599:v8::MaybeLocal<v8::Promise> 
node::loader::ImportModuleDynamically(v8::Local<v8::Context>, v8::Local<v8::Data>, v8::Local<v8::Value>, 
v8::Local<v8::String>, v8::Local<v8::FixedArray>): Assertion `(it) != (env->id_to_function_map.end())' failed.
```