### PR TITLE
UI (OPA) test: set Currency

### DIFF
--- a/app/travel_processor/layouts.cds
+++ b/app/travel_processor/layouts.cds
@@ -113,7 +113,8 @@ annotate TravelService.Travel with @UI : {
   ]},
   FieldGroup #PriceData : {Data : [
     { $Type : 'UI.DataField', Value : BookingFee },
-    { $Type : 'UI.DataField', Value : TotalPrice }
+    { $Type : 'UI.DataField', Value : TotalPrice },
+    { $Type : 'UI.DataField', Value : CurrencyCode_code }
   ]}
 };
 

--- a/app/travel_processor/webapp/test/integration/OpaJourney.js
+++ b/app/travel_processor/webapp/test/integration/OpaJourney.js
@@ -78,6 +78,11 @@ sap.ui.define(["sap/ui/test/opaQunit"], function (opaTest) {
           .onForm({ section: "Travel", fieldGroup: "PriceData" })
           .iChangeField({ property: "BookingFee" }, "50.00");
 
+        // Currency
+        When.onTheDetailPage
+          .onForm({ section: "Travel", fieldGroup: "PriceData" })
+          .iChangeField({ property: "CurrencyCode_code" }, "EUR");
+
         // Description
         When.onTheDetailPage
           .onForm({ section: "Travel", fieldGroup: "TravelData" })


### PR DESCRIPTION
Currently there is a bug in the test framework which apparently puts the BookingFee value (a number) also into the CurrencyField, which leads to an error. With this change the Currency is explicitly set to a valid value.