### PR TITLE
Make mock users configuration available to all profiles

### DIFF
--- a/srv/src/main/resources/application.yml
+++ b/srv/src/main/resources/application.yml
@@ -3,10 +3,7 @@ management:
         web:
             exposure:
                 include: "*"
----
-spring:
-    config.activate.on-profile: default
-    web.resources.static-locations: "file:./app"
+
 cds:
     security.mock.users:
     - name: rose
@@ -25,6 +22,11 @@ cds:
         endpoint:
             path: "/"
 
+---
+spring:
+    config.activate.on-profile: default
+    web.resources.static-locations: "file:./app"
+    
 server:
     port: 4004
 
@@ -36,6 +38,3 @@ spring:
 cds:
     datasource:
         csv.initialization-mode: never
-    odata-v4:
-        endpoint:
-            path: "/"


### PR DESCRIPTION
When running in the cloud profile (e.g. for testing locally with HANA -> hybrid scenario), it should be possible to use mock users. Enabling XSUAA by providing a corresponding binding will overrule the mock user configuration in productive scenarios.