### PR TITLE
Fix duplicated JSON dependency issues

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -45,6 +45,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.vaadin.external.google</groupId>
+          <artifactId>android-json</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
There is a conflict of a duplicated JSON dependency. Excluding the older one, ensures compatibility.