### PR TITLE
cosmetics: Add trailing `;` to projection-clause: fixes syntax highlight

### DIFF
--- a/srv/analytics-service.cds
+++ b/srv/analytics-service.cds
@@ -60,7 +60,7 @@ service AnalyticsService @(path:'/analytics') {
   };
 
   // for value help
-  entity BookingStatus as projection on my.BookingStatus
+  entity BookingStatus as projection on my.BookingStatus;
 
   // for detail page:
 


### PR DESCRIPTION
Syntax highlighting is broken if there is no trailing semicolon after a projection (without select clause). I'm surprised that this is supported, as at nearly all other places, a semicolon is allowed.