### PR TITLE
Reduce string length for status codes to reasonable size

### DIFF
--- a/db/master-data.cds
+++ b/db/master-data.cds
@@ -101,7 +101,7 @@ entity TravelAgency : MasterData {
 //
 
 entity SupplementType : sap.common.CodeList {
-  key code : String enum {
+  key code : String(2) enum {
     Beverage = 'BV';
     Meal     = 'ML';
     Luggage  = 'LU';

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -71,7 +71,7 @@ entity BookingSupplement : managed {
 //
 
 entity BookingStatus : CodeList {
-  key code : String enum {
+  key code : String(1) enum {
     New      = 'N';
     Booked   = 'B';
     Canceled = 'X';
@@ -79,7 +79,7 @@ entity BookingStatus : CodeList {
 };
 
 entity TravelStatus : CodeList {
-  key code : String enum {
+  key code : String(1) enum {
     Open     = 'O';
     Accepted = 'A';
     Canceled = 'X';


### PR DESCRIPTION
Without explicit length, default length is 5000 (HANA) or 255 (other DBs)