### PR TITLE
Apply @cds.collate : false to keys

### DIFF
--- a/db/master-data.cds
+++ b/db/master-data.cds
@@ -92,7 +92,7 @@ entity TravelAgency : MasterData {
   Street       : String(60);
   PostalCode   : String(10);
   City         : String(40);
-  CountryCode  : Country     @cds.collate : false;
+  CountryCode  : Country;
   PhoneNumber  : String(30);
   EMailAddress : String(256);
   WebAddress   : String(256);

--- a/db/master-data.cds
+++ b/db/master-data.cds
@@ -9,7 +9,7 @@ entity Airline : MasterData {
   key AirlineID : String(3) @cds.collate : false;
   Name          : String(40);
   CurrencyCode  : Currency;
-  AirlinePicURL : String      @UI : {IsImageURL : true} @cds.collate: false;
+  AirlinePicURL : String      @UI : {IsImageURL : true};
 
 };
 
@@ -78,8 +78,8 @@ entity Passenger : managed, MasterData {
   PostalCode     : String(10);
   City           : String(40);
   CountryCode    : Country     @cds.collate : false;
-  PhoneNumber    : String(30)  @cds.collate : false;
-  EMailAddress   : String(256) @cds.collate : false;
+  PhoneNumber    : String(30);
+  EMailAddress   : String(256);
 };
 
 entity TravelAgency : MasterData {
@@ -89,9 +89,9 @@ entity TravelAgency : MasterData {
   PostalCode   : String(10);
   City         : String(40);
   CountryCode  : Country     @cds.collate : false;
-  PhoneNumber  : String(30)  @cds.collate : false;
-  EMailAddress : String(256) @cds.collate : false;
-  WebAddress   : String(256) @cds.collate : false;
+  PhoneNumber  : String(30);
+  EMailAddress : String(256);
+  WebAddress   : String(256);
 };
 
 

--- a/db/master-data.cds
+++ b/db/master-data.cds
@@ -5,8 +5,12 @@ namespace sap.fe.cap.travel;
 @cds.autoexpose @readonly
 aspect MasterData {}
 
+// Annotation @cds.collate: false will disable language-dependent ordering.
+type AirlineId    : String(3) @cds.collate: false;
+type ConnectionId : String(4) @cds.collate: false;
+
 entity Airline : MasterData {
-  key AirlineID : String(3) @cds.collate : false;
+  key AirlineID : AirlineId;
   Name          : String(40);
   CurrencyCode  : Currency;
   AirlinePicURL : String      @UI : {IsImageURL : true};
@@ -34,9 +38,9 @@ entity Flight : MasterData {
   // when cuid is added, the to_Airline & to_Connection can be made managed association,
   // furthermore the AirlineID and ConnectionID can be removed,
   // they will be replaced by the generate FKs for to_Airline & to_Connection
-  key AirlineID    : String(3) @cds.collate : false;
+  key AirlineID    : AirlineId;
   key FlightDate   : Date;
-  key ConnectionID : String(4) @cds.collate : false;
+  key ConnectionID : ConnectionId;
 
   Price            : Decimal(16, 3);
   CurrencyCode     : Currency;
@@ -54,8 +58,8 @@ entity FlightConnection : MasterData {
   // once the TODO in Flight is done, similar change can be applied here
   // to_Airline can be managed association and AirlineID can be removed
   // and will be replaced with the generated FK
-  key ConnectionID   : String(4) @cds.collate : false;
-  key AirlineID      : String(3) @cds.collate : false;
+  key ConnectionID   : ConnectionId;
+  key AirlineID      : AirlineId;
   DepartureAirport   : Association to Airport;
   DestinationAirport : Association to Airport;
   DepartureTime      : Time;
@@ -77,7 +81,7 @@ entity Passenger : managed, MasterData {
   Street         : String(60);
   PostalCode     : String(10);
   City           : String(40);
-  CountryCode    : Country     @cds.collate : false;
+  CountryCode    : Country;
   PhoneNumber    : String(30);
   EMailAddress   : String(256);
 };

--- a/db/master-data.cds
+++ b/db/master-data.cds
@@ -5,17 +5,16 @@ namespace sap.fe.cap.travel;
 @cds.autoexpose @readonly
 aspect MasterData {}
 
-
 entity Airline : MasterData {
-  key AirlineID : String(3);
+  key AirlineID : String(3) @cds.collate : false;
   Name          : String(40);
   CurrencyCode  : Currency;
-  AirlinePicURL : String      @UI : {IsImageURL : true};
+  AirlinePicURL : String      @UI : {IsImageURL : true} @cds.collate: false;
 
 };
 
 entity Airport : MasterData {
-  key AirportID : String(3);
+  key AirportID : String(3) @cds.collate : false;
   Name          : String(40);
   City          : String(40);
   CountryCode   : Country;
@@ -23,7 +22,7 @@ entity Airport : MasterData {
 
 
 entity Supplement : managed, MasterData {
-  key SupplementID : String(10);
+  key SupplementID : String(10) @cds.collate : false;
   Price            : Decimal(16, 3);
   Type             : Association to SupplementType;
   Description      : localized String(1024);
@@ -35,9 +34,9 @@ entity Flight : MasterData {
   // when cuid is added, the to_Airline & to_Connection can be made managed association,
   // furthermore the AirlineID and ConnectionID can be removed,
   // they will be replaced by the generate FKs for to_Airline & to_Connection
-  key AirlineID    : String(3);
+  key AirlineID    : String(3) @cds.collate : false;
   key FlightDate   : Date;
-  key ConnectionID : String(4);
+  key ConnectionID : String(4) @cds.collate : false;
 
   Price            : Decimal(16, 3);
   CurrencyCode     : Currency;
@@ -55,8 +54,8 @@ entity FlightConnection : MasterData {
   // once the TODO in Flight is done, similar change can be applied here
   // to_Airline can be managed association and AirlineID can be removed
   // and will be replaced with the generated FK
-  key ConnectionID   : String(4);
-  key AirlineID      : String(3);
+  key ConnectionID   : String(4) @cds.collate : false;
+  key AirlineID      : String(3) @cds.collate : false;
   DepartureAirport   : Association to Airport;
   DestinationAirport : Association to Airport;
   DepartureTime      : Time;
@@ -71,28 +70,28 @@ entity FlightConnection : MasterData {
 // showcasing unique constrains ??
 // @assert.unique.email: [EMailAddress]
 entity Passenger : managed, MasterData {
-  key CustomerID : String(6);
+  key CustomerID : String(6)   @cds.collate : false;
   FirstName      : String(40);
   LastName       : String(40);
   Title          : String(10);
   Street         : String(60);
   PostalCode     : String(10);
   City           : String(40);
-  CountryCode    : Country;
-  PhoneNumber    : String(30);
-  EMailAddress   : String(256);
+  CountryCode    : Country     @cds.collate : false;
+  PhoneNumber    : String(30)  @cds.collate : false;
+  EMailAddress   : String(256) @cds.collate : false;
 };
 
 entity TravelAgency : MasterData {
-  key AgencyID : String(6);
+  key AgencyID : String(6)   @cds.collate : false;
   Name         : String(80);
   Street       : String(60);
   PostalCode   : String(10);
   City         : String(40);
-  CountryCode  : Country;
-  PhoneNumber  : String(30);
-  EMailAddress : String(256);
-  WebAddress   : String(256);
+  CountryCode  : Country     @cds.collate : false;
+  PhoneNumber  : String(30)  @cds.collate : false;
+  EMailAddress : String(256) @cds.collate : false;
+  WebAddress   : String(256) @cds.collate : false;
 };
 
 
@@ -101,6 +100,7 @@ entity TravelAgency : MasterData {
 //
 
 entity SupplementType : sap.common.CodeList {
+  @cds.collate: false
   key code : String enum {
     Beverage = 'BV';
     Meal     = 'ML';

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -4,7 +4,8 @@ using {
   sap.fe.cap.travel.Passenger,
   sap.fe.cap.travel.TravelAgency,
   sap.fe.cap.travel.Supplement,
-  sap.fe.cap.travel.Flight
+  sap.fe.cap.travel.Flight,
+  sap.fe.cap.travel.ConnectionId
  } from './master-data';
 
 namespace sap.fe.cap.travel;
@@ -41,7 +42,7 @@ entity Booking : managed {
   key BookingUUID   : UUID;
   BookingID         : Integer @Core.Computed;
   BookingDate       : Date;
-  ConnectionID      : String(4) @cds.collate : false;
+  ConnectionID      : ConnectionId;
   FlightDate        : Date;
   FlightPrice       : Decimal(16, 3);
   CurrencyCode      : Currency;

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -71,6 +71,7 @@ entity BookingSupplement : managed {
 //
 
 entity BookingStatus : CodeList {
+  @cds.collate: false
   key code : String(1) enum {
     New      = 'N';
     Booked   = 'B';
@@ -79,6 +80,7 @@ entity BookingStatus : CodeList {
 };
 
 entity TravelStatus : CodeList {
+  @cds.collate: false
   key code : String(1) enum {
     Open     = 'O';
     Accepted = 'A';

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -41,7 +41,7 @@ entity Booking : managed {
   key BookingUUID   : UUID;
   BookingID         : Integer @Core.Computed;
   BookingDate       : Date;
-  ConnectionID      : String(4);
+  ConnectionID      : String(4) @cds.collate : false;
   FlightDate        : Date;
   FlightPrice       : Decimal(16, 3);
   CurrencyCode      : Currency;
@@ -79,6 +79,7 @@ entity BookingStatus : CodeList {
 };
 
 entity TravelStatus : CodeList {
+  @cds.collate: false
   key code : String enum {
     Open     = 'O';
     Accepted = 'A';

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <!-- DEPENDENCIES VERSION -->
     <jdk.version>17</jdk.version>
-    <cds.services.version>2.2.0</cds.services.version>
+    <cds.services.version>2.3.0</cds.services.version>
 
     <cdsdk.version>^7</cdsdk.version>
   </properties>


### PR DESCRIPTION
This PR demonstrates the annotation `@cds.collate`that can be used to
disable language-depended ordering for String fields.