### PR TITLE
Downgrading ui5 version because app doesn't work in UI5 1.120

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm
+
+RUN wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+
+# install Linux packages
+RUN sudo apt-get update 
+RUN sudo apt-get install cf8-cli
+
+# install npm packages
+RUN npm install -g mbt @sap/cds-dk
+
+# addtional plugins to Cloud Foundry
+RUN cf install-plugin -f multiapps

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,13 +5,13 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
 		"dockerfile": "Dockerfile"
-	}
+	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	"postCreateCommand": "npm install"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/app/travel_analytics/webapp/index.html
+++ b/app/travel_analytics/webapp/index.html
@@ -16,7 +16,7 @@
     </style>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.119.2/resources/sap-ui-core.js"
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
       data-sap-ui-resourceroots='{ "sap.fe.cap.travel_analytics": "./" }'

--- a/app/travel_processor/webapp/index.html
+++ b/app/travel_processor/webapp/index.html
@@ -16,7 +16,7 @@
     </style>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.119.2/resources/sap-ui-core.js"
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
       data-sap-ui-resourceroots='{ "sap.fe.cap.travel": "." }'


### PR DESCRIPTION
Additionally I'd like to introduce devcontainer for those who don't want to set up a similar environment with preinstalled libraries version.