### PR TITLE
Set flexibility services correctly, bump UI5 version

### DIFF
--- a/app/travel_analytics/webapp/index.html
+++ b/app/travel_analytics/webapp/index.html
@@ -16,7 +16,7 @@
     </style>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/1.119.2/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.120.1/resources/sap-ui-core.js"
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
       data-sap-ui-resourceroots='{ "sap.fe.cap.travel_analytics": "./" }'

--- a/app/travel_analytics/webapp/index.html
+++ b/app/travel_analytics/webapp/index.html
@@ -23,7 +23,7 @@
       data-sap-ui-compatVersion="edge"
       data-sap-ui-async="true"
       data-sap-ui-preload="async"
-      data-sap-ui-flexibilityServices=""
+      data-sap-ui-flexibilityServices='[{"connector": "SessionStorageConnector"}]'
       data-sap-ui-frameOptions="trusted"
       data-sap-ui-libs="sap.m, sap.fe.core"
     ></script>

--- a/app/travel_processor/webapp/index.html
+++ b/app/travel_processor/webapp/index.html
@@ -16,7 +16,7 @@
     </style>
     <script
       id="sap-ui-bootstrap"
-      src="https://ui5.sap.com/1.119.2/resources/sap-ui-core.js"
+      src="https://ui5.sap.com/1.120.1/resources/sap-ui-core.js"
       data-sap-ui-theme="sap_horizon"
       data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
       data-sap-ui-resourceroots='{ "sap.fe.cap.travel": "." }'

--- a/app/travel_processor/webapp/index.html
+++ b/app/travel_processor/webapp/index.html
@@ -23,7 +23,7 @@
       data-sap-ui-compatVersion="edge"
       data-sap-ui-async="true"
       data-sap-ui-preload="async"
-      data-sap-ui-flexibilityServices=""
+      data-sap-ui-flexibilityServices='[{"connector": "SessionStorageConnector"}]'
       data-sap-ui-xx-componentPreload="off"
       data-sap-ui-libs="sap.m, sap.fe.core"
     ></script>


### PR DESCRIPTION
With a recent change in SAPUI5, flexibility services mustn't be set empty in the index.html, as this breaks the runtime when running with the actual SAPUI5 version.
This PR fixes the runtime issue and now also enables to e.g. save filter personalization variants when running the app locally.
Bumping the UI5 version to 1.120.1 in that course.