### PR TITLE
Automatic JS Conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test": "jest",
     "test:mocha": "npx mocha --timeout 20000",
     "travel-processor": "cds watch --open travel_processor/webapp/index.html?sap-ui-xx-viewCache=false",
-    "travel-analytics": "cds watch --open travel_analytics/webapp/index.html?sap-ui-xx-viewCache=false"
+    "travel-analytics": "cds watch --open travel_analytics/webapp/index.html?sap-ui-xx-viewCache=false",
+    "tsc": "tsc --project tsconfig.strip.json",
+    "format": "npx prettier -w srv/travel-service.js --print-width 300 --no-semi --single-quote",
+    "tojs": "npm run tsc && npm run format"
   },
   "dependencies": {
     "@sap/cds": ">=7.0.0",

--- a/tsconfig.strip.json
+++ b/tsconfig.strip.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "#cds-models/*": [
+        "./@cds-models/*"
+      ]
+    },
+    "target": "ESNext",
+    "module": "CommonJS",
+    "strict": true,
+    "esModuleInterop": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmitHelpers": true
+  },
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Recommended"
+}


### PR DESCRIPTION
Stacked on top of https://github.com/SAP-samples/cap-sflight/tree/typescript

Adds a script to automatically convert the TS example into a JS example that should differ as little as possible from the original source.
The plan is to have a process in place to have both a TS, as well as a JS version, but only actively maintain the TS version and automatically derive the JS version from it.