### PR TITLE
fix: Require current default UI5 version

### DIFF
--- a/app/travel_analytics/webapp/manifest.json
+++ b/app/travel_analytics/webapp/manifest.json
@@ -63,7 +63,7 @@
   "sap.ui5": {
     "flexEnabled": true,
     "dependencies": {
-      "minUI5Version": "1.121.1",
+      "minUI5Version": "1.120.6",
       "libs": {
         "sap.m": {},
         "sap.ui.core": {},

--- a/app/travel_processor/webapp/manifest.json
+++ b/app/travel_processor/webapp/manifest.json
@@ -71,7 +71,7 @@
       "css": []
     },
     "dependencies": {
-      "minUI5Version": "1.121.1",
+      "minUI5Version": "1.120.6",
       "libs": {
         "sap.ui.core": {},
         "sap.fe.templates": {}


### PR DESCRIPTION
UI5 1.121.1 is not supported by the language assistant yet, therefore reverting back to the current default version of 1.120.6