### PR TITLE
Java H2

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -5,6 +5,7 @@
     },
     "cdsc": {
         "fewerLocalizedViews": true,
-        "betterSqliteSessionVariables": true
+        "betterSqliteSessionVariables": true,
+        "withHanaAssociations" : false
     }
 }

--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,7 +1,10 @@
 {
 	"sql": {
+		"transitive_localized_views" : false,
+		"native_hana_associations" : false
 	},
 	"cdsc": {
+		"fewerLocalizedViews": true,
         "betterSqliteSessionVariables": true
     }
 }

--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,10 +1,10 @@
 {
-	"sql": {
-		"transitive_localized_views" : false,
-		"native_hana_associations" : false
-	},
-	"cdsc": {
-		"fewerLocalizedViews": true,
+    "sql": {
+        "transitive_localized_views" : false,
+        "native_hana_associations" : false
+    },
+    "cdsc": {
+        "fewerLocalizedViews": true,
         "betterSqliteSessionVariables": true
     }
 }

--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,4 +1,7 @@
 {
 	"sql": {
-	}
+	},
+	"cdsc": {
+        "betterSqliteSessionVariables": true
+    }
 }

--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,5 +1,4 @@
 {
 	"sql": {
-		"dialect": "plain"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hdb": "^0.19.1"
   },
   "devDependencies": {
+    "@cap-js/sqlite": "^1.0.1",
     "@sap/ux-specification": "UI5-1.121",
     "axios": "^1",
     "chai": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "hdb": "^0.19.1"
   },
   "devDependencies": {
-    "@cap-js/sqlite": "^1.0.1",
     "@sap/ux-specification": "UI5-1.121",
     "axios": "^1",
     "chai": "^4.3.0",

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -159,7 +159,7 @@
             <configuration>
               <commands>
                 <command>build --for java --opts contentLocalizedEdmx=false</command>
-                <command>deploy --to sql --dry &gt;
+                <command>deploy --to h2 --dry &gt;
 									"${project.basedir}/src/main/resources/schema.sql"</command>
               </commands>
             </configuration>


### PR DESCRIPTION
Configure CAP Java to use H2
* explicitly build for H2 in `cds deploy --dry`
* session variables
  * we need to specify `betterSqliteSessionVariables` as otherwise the locale is pinned to `en`
  * alternatively, we could remove the dependency to `@cap-js/sqlite`
* fewer localized views
  * enable `fewerLocalizedViews` -> 7.9 -> `transitive_localized_views : false`
  * disable `withHanaAssociations` -> 7.9 -> `native_hana_associations : false`