### PR TITLE
chore: align cds-rc.json and package.json config

### DIFF
--- a/.cdsrc.json
+++ b/.cdsrc.json
@@ -1,11 +1,1 @@
-{
-    "sql": {
-        "transitive_localized_views" : false,
-        "native_hana_associations" : false
-    },
-    "cdsc": {
-        "fewerLocalizedViews": true,
-        "betterSqliteSessionVariables": true,
-        "withHanaAssociations" : false
-    }
-}
+{}

--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
           }
         ]
       }
+    },
+    "sql": {
+      "transitive_localized_views" : false,
+      "native_hana_associations" : false
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -112,10 +112,7 @@
     },
     "sql": {
       "transitive_localized_views" : false,
-      "native_hana_associations" : false,
-      "cdsc": {
-        "betterSqliteSessionVariables": true
-    }
+      "native_hana_associations" : false
     }
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,10 @@
     },
     "sql": {
       "transitive_localized_views" : false,
-      "native_hana_associations" : false
+      "native_hana_associations" : false,
+      "cdsc": {
+        "betterSqliteSessionVariables": true
+    }
     }
   },
   "jest": {


### PR DESCRIPTION
I recently stumbled over the spread configuration within sflight when analyzing an issue.
If the configuration is not at a single place, it's very hard to quickly get an understanding of applied configurations.

I'd propose to only use package.json in sflight (alternatively use profiles).

In addition, the `cdsc` config should rather stay internal I think. @agoerler was there a specific reason to apply them as well? If yes, I think we should fix it.
