### PR TITLE
Remove Developer Dashboard

### DIFF
--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -26,11 +26,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sap.cds</groupId>
-      <artifactId>cds-feature-dev-dashboard</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>runtime</scope>
@@ -95,13 +90,6 @@
             </goals>
             <configuration>
               <classifier>exec</classifier>
-              <!-- Exclude dashboard for production-->
-              <excludes>
-                <exclude>
-                  <groupId>com.sap.cds</groupId>
-                  <artifactId>cds-feature-dev-dashboard</artifactId>
-                </exclude>
-              </excludes>
             </configuration>
           </execution>
         </executions>

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -27,7 +27,6 @@
 
     <dependency>
       <groupId>com.sap.cds</groupId>
-      <!-- Use only for development. Remove in production! -->
       <artifactId>cds-feature-dev-dashboard</artifactId>
     </dependency>
 
@@ -96,6 +95,13 @@
             </goals>
             <configuration>
               <classifier>exec</classifier>
+              <!-- Exclude dashboard for production-->
+              <excludes>
+                <exclude>
+                  <groupId>com.sap.cds</groupId>
+                  <artifactId>cds-feature-dev-dashboard</artifactId>
+                </exclude>
+              </excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Not supported yet in Native Images and breaks our tests, thus removed until a fix is available.