### PR TITLE
build-ui-image.sh: Adjust image tag to updated helm chart

### DIFF
--- a/deployment/kyma/scripts/build-ui-image.sh
+++ b/deployment/kyma/scripts/build-ui-image.sh
@@ -12,7 +12,7 @@ function value() {
 
 function image() {
     local REPOSITORY="$(value "$1.image.repository")"
-    local TAG="$(value "$1.image.tag")"
+    local TAG="$(value "global.image.tag")"
     if [ "$TAG" != "" ]; then
         echo "$REPOSITORY:$TAG"
     else


### PR DESCRIPTION
The structure of the _values.yml_ file which will be added via `cds add helm` has changed. The image tag is now defined in the global property which requires this adjustment in the _build-ui-image.sh_ script. (Details: https://cap.cloud.sap/docs/releases/jun24#changes-in-the-helm-chart)