### PR TITLE
fix: keys must be UI.Hidden instead of Core.Computed

### DIFF
--- a/app/common.cds
+++ b/app/common.cds
@@ -2,6 +2,6 @@ using { Currency } from '../db/common';
 
 
 // Workarounds for overly strict OData libs and clients
-annotate cds.UUID with @Core.Computed  @odata.Type : 'Edm.String';
+annotate cds.UUID with @UI.Hidden  @odata.Type : 'Edm.String';
 
 annotate Currency with @Common.UnitSpecificScale : 'Decimals';


### PR DESCRIPTION
`@Core.Computed` is not supported for keys (for example, it's problematic in deep updates). To prevent the Fiori elements popup, we must rather use `@UI.Hidden`.