### PR TITLE
Configure cds-types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
             "#cds-models/*": [
                 "./@cds-models/*"
             ]
-        }
+        },
+        "types": [
+            "@cap-js/cds-types"
+        ],
     },
     "include": [
         "./srv/**/*"


### PR DESCRIPTION
This makes the existence of the symlink from cds-types obsolete.