### PR TITLE
disable ui5 plugin for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     ],
     "require": "test/setup.ts",
     "spec": "test/**/*.ts",
-    "timeout": 200000
+    "timeout": 20000
   },
   "sapux": [
     "app/travel_processor",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "npx eslint .",
     "start": "cds-serve",
     "test": "jest",
-    "test:mocha": "npx -y mocha --exit",
+    "test:mocha": "npx -y mocha",
     "travel-processor": "cds-tsx watch --open sap.fe.cap.travel/index.html?sap-ui-xx-viewCache=false",
     "travel-analytics": "cds-tsx watch --open sap.fe.cap.travel_analytics/index.html?sap-ui-xx-viewCache=false"
   },
@@ -140,7 +140,7 @@
     ],
     "require": "test/setup.ts",
     "spec": "test/**/*.ts",
-    "timeout": 20000
+    "timeout": 200000
   },
   "sapux": [
     "app/travel_processor",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,6 @@
 // for mocha
 process.env.CDS_TYPESCRIPT = "true"
+// disables cds-ui5-plugin as otherwise it would not let mocha tests terminate
 process.env.CDS_PLUGIN_UI5_ACTIVE="false"
 
 // for jest

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,6 @@
 // for mocha
 process.env.CDS_TYPESCRIPT = "true"
+process.env.CDS_PLUGIN_UI5_ACTIVE="false"
 
 // for jest
 module.exports = async () => {}


### PR DESCRIPTION
Disables the cds ui5 plugin for mocha tests, removing the need for the forceful mocha exit introduced with #1286 .

@c-kobo ideally the plugin could detect that it's in a test environment, like it does with jest.