### PR TITLE
Allow serving UI from `dist/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,29 @@ npx cds-typer "*"
 cds-tsx watch
 ```
 
+#### Accessing the SAP Fiori Apps
+
+Open these links in your browser:
+* http://localhost:4004/sap.fe.cap.travel/index.html for processing the travel data
+* http://localhost:4004/sap.fe.cap.travel_analytics/index.html for the [Analytical List Page](https://ui5.sap.com/#/topic/3d33684b08ca4490b26a844b6ce19b83) (ALP)
+
+
 ### Build and Run - Java Backend
 
 In the root folder of your project, run
 ```
 npm ci
+npm run build:ui
 mvn spring-boot:run
 ```
 
-### Accessing the SAP Fiori Apps
+> At the moment, there is no watch mode for Fiori UI changes.  Run `npm run build:ui` after each change there.
+
+#### Accessing the SAP Fiori Apps
 
 Open these links in your browser:
-* http://localhost:4004/travel_processor/webapp/index.html for processing the travel data
-* http://localhost:4004/travel_analytics/webapp/index.html for the [Analytical List Page](https://ui5.sap.com/#/topic/3d33684b08ca4490b26a844b6ce19b83) (ALP)
+* http://localhost:4004/travel_processor/dist/index.html for processing the travel data
+* http://localhost:4004/travel_analytics/dist/index.html for the [Analytical List Page](https://ui5.sap.com/#/topic/3d33684b08ca4490b26a844b6ce19b83) (ALP)
 
 Log in with user `amy` and empty password.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "lint": "npx eslint .",
     "start": "cds-serve",
+    "build:ui": "npm run build --prefix app/travel_analytics && npm run build --prefix app/travel_processor",
     "test": "jest",
     "test:mocha": "npx -y mocha",
     "travel-processor": "cds-tsx watch --open sap.fe.cap.travel/index.html?sap-ui-xx-viewCache=false",

--- a/srv/src/main/java/com/sap/cap/sflight/ui/RedirectFilter.java
+++ b/srv/src/main/java/com/sap/cap/sflight/ui/RedirectFilter.java
@@ -28,7 +28,9 @@ public class RedirectFilter extends GenericFilterBean {
 
         String[] uiServicePaths = {
             "/travel_processor/webapp/processor",
-            "/travel_analytics/webapp/analytics"
+            "/travel_analytics/webapp/analytics",
+            "/travel_processor/dist/processor",
+            "/travel_analytics/dist/analytics"
         };
 
         String path = req.getRequestURI();


### PR DESCRIPTION
To allow serving UI from the build result in `dist/`, add the same redirects to than for `webapp/`, so that relative service URLs work again.

Mitigates issue #1314