### PR TITLE
Removed native-image.properties

### DIFF
--- a/srv/src/main/resources/META-INF/native-image/native-image.properties
+++ b/srv/src/main/resources/META-INF/native-image/native-image.properties
@@ -1,1 +1,0 @@
-Args = --initialize-at-run-time=sun.nio.ch.AsynchronousSocketChannelImpl$DefaultOptionsHolder,sun.nio.ch.SocketChannelImpl$DefaultOptionsHolder


### PR DESCRIPTION
Removed obsolete native-image.properties which is no longer required with a minimum Java requirement of JVM 21