### PR TITLE
Fix Chrome start in CI

### DIFF
--- a/app/.karma/karma.conf.js
+++ b/app/.karma/karma.conf.js
@@ -28,7 +28,13 @@ module.exports = async (config) => {
     },
     plugins: [...config.plugins, await capMiddleware],
     middleware: ["cap-proxy"],
-    browsers: config.ci ? ["ChromeHeadless"] : ["Chrome"],
+    browsers: config.ci ? ["ChromeHeadlessNoSandbox"] : ["Chrome"],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
     singleRun: config.ci || config.singleRun || false
   });
 };


### PR DESCRIPTION
For some reason, ChromeHeadless doesn't start anymore unless given `--no-sandbox`.
As the whole thing runs in a container anyway, `--no-sandbox` shouldn't do any harm.