### PR TITLE
Remove test in cloud profile

### DIFF
--- a/srv/src/test/java/com/sap/cap/sflight/processor/UpdateFlightSeatsHandlerServiceIntegrationTest.java
+++ b/srv/src/test/java/com/sap/cap/sflight/processor/UpdateFlightSeatsHandlerServiceIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit.jupiter.EnabledIf;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDate;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
+@EnabledIf(value = "#{environment.getActiveProfiles()[0] != 'cloud'}")
 class UpdateFlightSeatsHandlerServiceIntegrationTest {
 
 

--- a/srv/src/test/java/com/sap/cap/sflight/processor/UpdateFlightSeatsHandlerServiceIntegrationTest.java
+++ b/srv/src/test/java/com/sap/cap/sflight/processor/UpdateFlightSeatsHandlerServiceIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -29,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
-@EnabledIf(value = "#{environment.getActiveProfiles()[0] != 'cloud'}")
+@EnabledIf(value = "#{environment.matchesProfiles('!cloud')}")
 class UpdateFlightSeatsHandlerServiceIntegrationTest {
 
 


### PR DESCRIPTION
Fixes https://github.com/SAP-samples/cap-sflight/pull/1358

This test depends on the fact that the state of the data is initial. 

Disables the test in question when application is tested against HANA container. We could also refresh the container or upload the data there again, but I do not think that this particular test is important there. 

Not perfect, though. E.g. test will fail if one uses `default-env.json`. 