### PR TITLE
Remove `eslint-plugin-fiori-tools`

### DIFF
--- a/app/travel_analytics/package.json
+++ b/app/travel_analytics/package.json
@@ -24,7 +24,6 @@
     "sapui5"
   ],
   "devDependencies": {
-    "@sap-ux/eslint-plugin-fiori-tools": "^0",
     "@sap/ux-ui5-tooling": "1",
     "@sapui5/types": "^1.130.0",
     "@typescript-eslint/eslint-plugin": "^8",

--- a/app/travel_processor/.eslintrc
+++ b/app/travel_processor/.eslintrc
@@ -1,4 +1,0 @@
-{
-    "extends": "plugin:@sap-ux/eslint-plugin-fiori-tools/defaultTS",
-    "root": true   
-}

--- a/app/travel_processor/package.json
+++ b/app/travel_processor/package.json
@@ -23,7 +23,6 @@
     "sapui5"
   ],
   "devDependencies": {
-    "@sap-ux/eslint-plugin-fiori-tools": "^0",
     "@sap/ux-ui5-tooling": "1",
     "@sapui5/types": "^1.130.0",
     "@typescript-eslint/eslint-plugin": "^8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
       "name": "travel-analytics",
       "version": "1.0.0",
       "devDependencies": {
-        "@sap-ux/eslint-plugin-fiori-tools": "^0",
         "@sap/ux-ui5-tooling": "1",
         "@sapui5/types": "^1.130.0",
         "@typescript-eslint/eslint-plugin": "^8",
@@ -68,7 +67,6 @@
       "name": "travel-processor",
       "version": "1.0.0",
       "devDependencies": {
-        "@sap-ux/eslint-plugin-fiori-tools": "^0",
         "@sap/ux-ui5-tooling": "1",
         "@sapui5/types": "^1.130.0",
         "@typescript-eslint/eslint-plugin": "^8",
@@ -114,6 +112,7 @@
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
       "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -126,6 +125,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
       "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.11.0",
@@ -140,6 +140,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.11.0.tgz",
       "integrity": "sha512-DxOSLua+NdpWoSqULhjDyAZTXFdP/LKkqtYuxxz1SCN289zk3OG8UOpnCQAz/tygyACBtWp/BoO72ptK7msY8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "tslib": "^2.6.2"
@@ -153,6 +154,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.10.1.tgz",
       "integrity": "sha512-Kji9k6TOFRDB5ZMTw8qUf2IJ+CeJtsuMdAHox9eqpTf1cefiNMpzrfnF6sINEBZJsaVaWgQ0o48B6kcUH68niA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.4.0",
@@ -174,6 +176,7 @@
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -186,6 +189,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -198,6 +202,7 @@
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -212,6 +217,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -225,6 +231,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -234,6 +241,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
       "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -246,6 +254,7 @@
       "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.2.0.tgz",
       "integrity": "sha512-ffGIw+Qs8bNKNLxz5UPkz4/VBM/EZY07mPve1ZYFqYUdPwFqRj0RPk0U7LZMOfT7GCck9YjuT1Rfp1PApNl1ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "tslib": "^2.2.0"
@@ -259,6 +268,7 @@
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
       "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -271,6 +281,7 @@
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.4.tgz",
       "integrity": "sha512-4IXXzcCdLdlXuCG+8UKEwLA1T1NHqUfanhXYHiQTn+6sfWCZXduqbtXDGceg3Ce5QxTGo7EqmbV6Bi+aqKuClQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -283,6 +294,7 @@
       "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.7.tgz",
       "integrity": "sha512-boG33EDRcbw0Jo2cRgB6bccSirKOzYdYFMdcSsnOajLCLfJ8WIve3vxUMi7YZKxM8txZX/0cwzUU6crXmYxXZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/core-tracing": "^1.2.0",
         "@azure/logger": "^1.0.0",
@@ -321,22 +333,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
+      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.26.0",
-        "@babel/generator": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.0",
-        "@babel/parser": "^7.26.0",
+        "@babel/helpers": "^7.26.7",
+        "@babel/parser": "^7.26.7",
         "@babel/template": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.26.0",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -677,27 +689,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.26.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.7.tgz",
+      "integrity": "sha512-kEvgGGgEjRUutvdVvZhbn/BxVt+5VSpwXz1j3WYXQbXDo8KzFOPNG2GQbdAiNq8g6wn1yKk7C/qrke03a84V+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.5"
+        "@babel/types": "^7.26.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1840,13 +1852,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
-      "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz",
+      "integrity": "sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
+        "@babel/helper-plugin-utils": "^7.26.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1856,9 +1868,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.5.tgz",
-      "integrity": "sha512-GJhPO0y8SD5EYVCy2Zr+9dSZcEgaSmq5BLR0Oc25TOEhC+ba49vUAGZFjy8v79z9E1mdldq4x9d1xgh4L1d5dQ==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.7.tgz",
+      "integrity": "sha512-5cJurntg+AT+cgelGP9Bt788DKiAw9gIMSMU2NJrLAilnj0m8WZWUNZPSLOmadYsujHutpgElO+50foX+ib/Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1943,15 +1955,15 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.7.tgz",
+      "integrity": "sha512-Ycg2tnXwixaXOVb29rana8HNPgLVBof8qqtNQ9LE22IoyZboQbGSxI6ZySMdW3K5nAe6gu35IaJefUJflhUFTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.26.0",
-        "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-validator-option": "^7.25.9",
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
         "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
@@ -1965,7 +1977,7 @@
         "@babel/plugin-transform-arrow-functions": "^7.25.9",
         "@babel/plugin-transform-async-generator-functions": "^7.25.9",
         "@babel/plugin-transform-async-to-generator": "^7.25.9",
-        "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+        "@babel/plugin-transform-block-scoped-functions": "^7.26.5",
         "@babel/plugin-transform-block-scoping": "^7.25.9",
         "@babel/plugin-transform-class-properties": "^7.25.9",
         "@babel/plugin-transform-class-static-block": "^7.26.0",
@@ -1976,7 +1988,7 @@
         "@babel/plugin-transform-duplicate-keys": "^7.25.9",
         "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
         "@babel/plugin-transform-dynamic-import": "^7.25.9",
-        "@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.26.3",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
         "@babel/plugin-transform-for-of": "^7.25.9",
         "@babel/plugin-transform-function-name": "^7.25.9",
@@ -1985,12 +1997,12 @@
         "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
         "@babel/plugin-transform-member-expression-literals": "^7.25.9",
         "@babel/plugin-transform-modules-amd": "^7.25.9",
-        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.26.3",
         "@babel/plugin-transform-modules-systemjs": "^7.25.9",
         "@babel/plugin-transform-modules-umd": "^7.25.9",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
         "@babel/plugin-transform-new-target": "^7.25.9",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
         "@babel/plugin-transform-numeric-separator": "^7.25.9",
         "@babel/plugin-transform-object-rest-spread": "^7.25.9",
         "@babel/plugin-transform-object-super": "^7.25.9",
@@ -2007,7 +2019,7 @@
         "@babel/plugin-transform-spread": "^7.25.9",
         "@babel/plugin-transform-sticky-regex": "^7.25.9",
         "@babel/plugin-transform-template-literals": "^7.25.9",
-        "@babel/plugin-transform-typeof-symbol": "^7.25.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.26.7",
         "@babel/plugin-transform-unicode-escapes": "^7.25.9",
         "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
         "@babel/plugin-transform-unicode-regex": "^7.25.9",
@@ -2072,9 +2084,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
+      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2100,17 +2112,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
-      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.7.tgz",
+      "integrity": "sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "@babel/generator": "^7.26.5",
-        "@babel/parser": "^7.26.5",
+        "@babel/parser": "^7.26.7",
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.5",
+        "@babel/types": "^7.26.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2129,9 +2141,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.7.tgz",
+      "integrity": "sha512-t8kDRGrKXyp6+tjUh7hw2RLyclsW4TRoRvRHtSyAX9Bb5ldlFh+90YAYY6awRXrlB4G5G2izNeGySpATlFzmOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2150,9 +2162,9 @@
       "license": "MIT"
     },
     "node_modules/@cap-js/cds-typer": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/cds-typer/-/cds-typer-0.32.0.tgz",
-      "integrity": "sha512-2e266nKAFZHI1yfghFrhuLl8LynWFM+2TpCYdwSlRwCVNEPoe1I/dloe+ei+wTGfEqRsnURMxlcGOyblTGrh9A==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@cap-js/cds-typer/-/cds-typer-0.32.1.tgz",
+      "integrity": "sha512-ZiYIdTr2pW6MF/FE2sXLaLoAXTPew5ZPdC7K7xaxE5M31MFKtM5OAqlWURvjsTZOL5dM6agL0WWhRupeeUFCew==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
@@ -2176,9 +2188,9 @@
       }
     },
     "node_modules/@cap-js/db-service": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@cap-js/db-service/-/db-service-1.16.2.tgz",
-      "integrity": "sha512-B9XSThHB3McPYBGP1Lty4/I5edD6aCcBFKRLYIqUj2u6gIzHNJXu1TIHicGwWb/e6Plp2+ntwTQ01DgMp6Xgtg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@cap-js/db-service/-/db-service-1.17.1.tgz",
+      "integrity": "sha512-sHGPyF2qBF5YhU3bMWGa4V6rVE8ZvauxyTc0f0a0fMmgL6/I4p8JVDvbmtvF6ajoeWFKRJEvikC9M5Q9vwMImA==",
       "license": "SEE LICENSE",
       "dependencies": {
         "generic-pool": "^3.9.0"
@@ -2188,12 +2200,12 @@
       }
     },
     "node_modules/@cap-js/hana": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@cap-js/hana/-/hana-1.5.2.tgz",
-      "integrity": "sha512-8+fxzHHiJEFL0KZtuCKwKFu1HmZA3mvyEfWEbd7w81MSmsvCqkrrKpix0cEvnaG2pahxuAECDthqiQJ3GMLFVQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@cap-js/hana/-/hana-1.6.1.tgz",
+      "integrity": "sha512-nU0AsRBLFzJalSs0/2QyC+RO7al9YnKcBoh5cYeXd0J6EKE9DDOcykuM/4qUiV1mZtnsrRtwcxVTM7OfIvc7xA==",
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1.16.1",
+        "@cap-js/db-service": "^1.17.0",
         "hdb": "^0.19.5"
       },
       "peerDependencies": {
@@ -2207,13 +2219,13 @@
       }
     },
     "node_modules/@cap-js/sqlite": {
-      "version": "1.7.8",
-      "resolved": "https://registry.npmjs.org/@cap-js/sqlite/-/sqlite-1.7.8.tgz",
-      "integrity": "sha512-llFn0LGNIdlsfU4KjzyuIMvlQhKxXodq4GIt9yStmmX/av/twwHR8SyUmTJirRH4IkNtpCsuNYpsI+bYO2Xklg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/sqlite/-/sqlite-1.8.0.tgz",
+      "integrity": "sha512-Qd/IrSksT+NWUopwtKnKMSs4pPnzfXJiILycK5CkZH3dKju9xpUvHBYxJF5uXBnN6UOhFURXXyvJ0BArk40nvQ==",
       "dev": true,
       "license": "SEE LICENSE",
       "dependencies": {
-        "@cap-js/db-service": "^1.14.1",
+        "@cap-js/db-service": "^1.17.0",
         "better-sqlite3": "^11.0.0"
       },
       "peerDependencies": {
@@ -2693,13 +2705,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -2793,9 +2805,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
-      "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2803,9 +2815,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2896,7 +2908,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -2914,14 +2926,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -2939,7 +2951,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -3603,31 +3615,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.2.1.tgz",
       "integrity": "sha512-+Cy9zFqdQgdAbMK1dpm7B+3DUnrByai0Tq6XG9v737HJpW6G1EiNNbTuFeXdPWyGaq6FIx9jxm/SUcxA6/Rxxg==",
-      "dev": true
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
-      "version": "5.1.1-v1",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
-      "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-scope": "5.1.1"
-      }
-    },
-    "node_modules/@nicolo-ribaudo/eslint-scope-5-internals/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3808,9 +3797,9 @@
       }
     },
     "node_modules/@npmcli/package-json": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.1.0.tgz",
-      "integrity": "sha512-t6G+6ZInT4X+tqj2i+wlLIeCKnKOTuz9/VFYDtj+TGTur5q7sp/OYrQA19LdBbWfXDOi0Y4jtedV6xtB8zQ9ug==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-6.1.1.tgz",
+      "integrity": "sha512-d5qimadRAUCO4A/Txw71VM7UrRZzV+NPclxz/dc+M6B2oYwjWTjqh8HA/sGQgs9VZuJ6I/P7XIAlJvgrl27ZOw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3818,9 +3807,9 @@
         "glob": "^10.2.2",
         "hosted-git-info": "^8.0.0",
         "json-parse-even-better-errors": "^4.0.0",
-        "normalize-package-data": "^7.0.0",
         "proc-log": "^5.0.0",
-        "semver": "^7.5.3"
+        "semver": "^7.5.3",
+        "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -3850,9 +3839,9 @@
       }
     },
     "node_modules/@npmcli/redact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.0.0.tgz",
-      "integrity": "sha512-/1uFzjVcfzqrgCeGW7+SZ4hv0qLWmKXVzFahZGJ6QuJBj6Myt9s17+JL86i76NV9YSnJRcGXJYQbAU0rn1YTCQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-3.1.1.tgz",
+      "integrity": "sha512-3Hc2KGIkrvJWJqTbvueXzBeZlmvoOxc2jyX00yzr3+sNFquJg0N8hH4SAPLPVrkWIRQICVpVgjrss971awXVnA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -3882,6 +3871,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3891,6 +3881,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
       "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -3903,6 +3894,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -3918,6 +3910,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
       "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.53.0",
         "@types/shimmer": "^1.2.0",
@@ -3938,6 +3931,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -3954,6 +3948,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -3971,6 +3966,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -4032,9 +4028,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.7.0.tgz",
-      "integrity": "sha512-bO61XnTuopsz9kvtfqhVbH6LTM1koxK0IlBR+yuVrM2LB7mk8+5o1w18l5zqd5cs8xlf+ntgambqRqGifMDjog==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.7.1.tgz",
+      "integrity": "sha512-MK7rtm8JjaxPN7Mf1JdZIZKPD2Z+W7osvrC1vjpvfOX1K0awDIHYbNi89f7eotp7eMUn2shWnt03HwVbriXtKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4042,9 +4038,8 @@
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.6.3",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
+        "semver": "^7.7.0",
+        "tar-fs": "^3.0.8",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4055,9 +4050,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4095,20 +4090,21 @@
       }
     },
     "node_modules/@sap-ux/adp-tooling": {
-      "version": "0.12.108",
-      "resolved": "https://registry.npmjs.org/@sap-ux/adp-tooling/-/adp-tooling-0.12.108.tgz",
-      "integrity": "sha512-frWX6Nr9GdJ79DFRDUqvUl431Uzlbrer2KxsPnZTnfUVv+bSgnPt3FsFHR+SanVoa/7pJ5U73vym+MsVUpZ05Q==",
+      "version": "0.12.112",
+      "resolved": "https://registry.npmjs.org/@sap-ux/adp-tooling/-/adp-tooling-0.12.112.tgz",
+      "integrity": "sha512-BzJbCpBK1tJaZu0gCb+Mzh47ZSYVrJzLBJu+iEjDYGfHh/D9HaYsFSCa6yPE549Uz9dYDCm/Kjx9sc7DNhHh4g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sap-ux/axios-extension": "1.18.0",
+        "@sap-ux/axios-extension": "1.18.1",
         "@sap-ux/btp-utils": "0.17.2",
         "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/inquirer-common": "0.6.3",
+        "@sap-ux/inquirer-common": "0.6.5",
         "@sap-ux/logger": "0.6.0",
-        "@sap-ux/odata-service-writer": "0.25.2",
-        "@sap-ux/project-access": "1.28.10",
+        "@sap-ux/odata-service-writer": "0.25.3",
+        "@sap-ux/project-access": "1.29.0",
         "@sap-ux/project-input-validator": "0.3.4",
-        "@sap-ux/system-access": "0.5.25",
+        "@sap-ux/system-access": "0.5.26",
         "@sap-ux/ui5-config": "0.26.0",
         "adm-zip": "0.5.10",
         "ejs": "3.1.10",
@@ -4119,25 +4115,6 @@
         "prompts": "2.4.2",
         "sanitize-filename": "1.6.3",
         "uuid": "10.0.0"
-      },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
-    "node_modules/@sap-ux/adp-tooling/node_modules/@sap-ux/project-access": {
-      "version": "1.28.10",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.10.tgz",
-      "integrity": "sha512-UB7zHjj6XBiy9NEenBXkHzCX+i1GpV/XjXdWYiSmWPvbToBprNI84orsslQLWWJhuifZzw7+87Uf5ujDLabVGw==",
-      "dev": true,
-      "dependencies": {
-        "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/ui5-config": "0.26.0",
-        "fast-xml-parser": "4.4.1",
-        "findit2": "2.2.3",
-        "json-parse-even-better-errors": "3.0.2",
-        "mem-fs": "2.1.0",
-        "mem-fs-editor": "9.4.0",
-        "semver": "7.5.4"
       },
       "engines": {
         "node": ">=18.x"
@@ -4162,6 +4139,7 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -4171,6 +4149,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/annotation-converter/-/annotation-converter-0.9.10.tgz",
       "integrity": "sha512-lZNcTLMoGUSGooYfKYLNy0SO0Ma6Z7kdGODPkbph6ur83+C6s+rJJ96jzziZT9gjVK8UoVy8qmZyjEZzEJgkeg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/vocabularies-types": "0.11.7"
       }
@@ -4180,15 +4159,17 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/vocabularies-types/-/vocabularies-types-0.11.7.tgz",
       "integrity": "sha512-rqRhmPW97dQ8K6nYjL1aP0a4THsUSGK6F5LSOOkSkyTQrBOGu5LNdqi90V2EYKSdIARTvgOnaz1mU+nmkzrsOA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.x"
       }
     },
     "node_modules/@sap-ux/axios-extension": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/@sap-ux/axios-extension/-/axios-extension-1.18.0.tgz",
-      "integrity": "sha512-ByIQY6DDG1VkDD9K4uTG9XEryf3axA2YhXzGo+ffM6mSVFugIPF0GiHlCZh1yUG0hPsvGlRn6GAxB0cVOYJiiA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@sap-ux/axios-extension/-/axios-extension-1.18.1.tgz",
+      "integrity": "sha512-JMh8eNun1IsHT3HJki1n/pUAXuySUzJd1gOHx76+gCGY6XJUJFKAaLLhWNM2BdUHXGdupGF4y+MccRb/pLuiqw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/btp-utils": "0.17.2",
         "@sap-ux/feature-toggle": "0.2.3",
@@ -4214,6 +4195,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4225,6 +4207,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
       "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -4238,6 +4221,7 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
       "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -4253,6 +4237,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/btp-utils/-/btp-utils-0.17.2.tgz",
       "integrity": "sha512-depW5gjg5ZIL0BdHBI77Lb1AcyzazCA7HF7P6lghHUox4myZu9Lt2U2Me/YOcZ1xUrrfOCIz4DqQK7ADVWgxsQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap/cf-tools": "3.2.2",
         "axios": "1.7.4"
@@ -4266,6 +4251,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4273,27 +4259,29 @@
       }
     },
     "node_modules/@sap-ux/cds-annotation-parser": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@sap-ux/cds-annotation-parser/-/cds-annotation-parser-0.2.4.tgz",
-      "integrity": "sha512-KFfuKkRDEpRym/lQSTaX0abdU7ajz73TvZiMRdn+iDfK1R4M/Zu53ZtPoPzqBdIV+/4BpWUqXOqEMTA+GwahwQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@sap-ux/cds-annotation-parser/-/cds-annotation-parser-0.2.5.tgz",
+      "integrity": "sha512-jHcWYrx522QqLgBcDpxCAF3cfOGcnwb6AMgO4UDKgbRon5z38F40jhz+j+TQ02Y7jx5mNEwPBD5dnhJ0pfrFSQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/odata-annotation-core": "0.2.2",
         "@sap-ux/odata-entity-model": "0.3.1",
-        "@sap-ux/odata-vocabularies": "0.4.4",
+        "@sap-ux/odata-vocabularies": "0.4.5",
         "@sap-ux/text-document-utils": "0.2.0",
         "chevrotain": "7.1.1"
       }
     },
     "node_modules/@sap-ux/cds-odata-annotation-converter": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@sap-ux/cds-odata-annotation-converter/-/cds-odata-annotation-converter-0.3.9.tgz",
-      "integrity": "sha512-d3pzSrWQhcZI2iOf6GDyxdVY1CFWMdF4SeTk3gERz8yDrwUmv7e2UUHoAnEAqWyHbJ8Z0omhARGN1Q1TqGex6g==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@sap-ux/cds-odata-annotation-converter/-/cds-odata-annotation-converter-0.3.10.tgz",
+      "integrity": "sha512-ErKFwPL7xW/H5NWZA3U9Vwbq4I0Ete4nR6r6k3h3Cvn4GWDUD6yV5yrZU4msVulniRTgTSS57nWQXbw8mjCFMA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sap-ux/cds-annotation-parser": "0.2.4",
+        "@sap-ux/cds-annotation-parser": "0.2.5",
         "@sap-ux/odata-annotation-core": "0.2.2",
-        "@sap-ux/odata-vocabularies": "0.4.4",
+        "@sap-ux/odata-vocabularies": "0.4.5",
         "@sap-ux/text-document-utils": "0.2.0",
         "@sap/ux-cds-compiler-facade": "1.15.1",
         "i18next": "20.6.1"
@@ -4304,6 +4292,7 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
       "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
@@ -4313,46 +4302,19 @@
       "version": "0.5.32",
       "resolved": "https://registry.npmjs.org/@sap-ux/control-property-editor/-/control-property-editor-0.5.32.tgz",
       "integrity": "sha512-VyODH/RlRHQ77WDF6FGm0GKSGe1FpQkOaeDLFAwctjpfuWr436HyG6UVmKcG2xT3q2ZUvLn5kK6RIcJsdWkh3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
-    "node_modules/@sap-ux/eslint-plugin-fiori-tools": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@sap-ux/eslint-plugin-fiori-tools/-/eslint-plugin-fiori-tools-0.5.0.tgz",
-      "integrity": "sha512-84PqhnuQU/J9TNDireAgW5ca7hrXQ3Ugqg42QYljtmsXyFTdjURspalQyCL5I3O9Klg78QhASBO94UiQe4sr1w==",
+    "node_modules/@sap-ux/fe-fpm-writer": {
+      "version": "0.31.25",
+      "resolved": "https://registry.npmjs.org/@sap-ux/fe-fpm-writer/-/fe-fpm-writer-0.31.25.tgz",
+      "integrity": "sha512-4hdx6ri7Cdsu48yA/BT4IuNd+bD0S1C+2FC7Xm2MORXhSUcz4+esQfw3lupG7J7D8JegywdEen32rz7s29JfSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "eslint-plugin-fiori-custom": "^2.6.7",
-        "yaml": "2.2.2"
-      },
-      "engines": {
-        "node": ">=18.x"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": ">=7.1.1",
-        "@typescript-eslint/parser": ">=5.62.0",
-        "eslint": ">=8"
-      }
-    },
-    "node_modules/@sap-ux/eslint-plugin-fiori-tools/node_modules/yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@sap-ux/fe-fpm-writer": {
-      "version": "0.31.23",
-      "resolved": "https://registry.npmjs.org/@sap-ux/fe-fpm-writer/-/fe-fpm-writer-0.31.23.tgz",
-      "integrity": "sha512-GqywhNGJmxyC8EGvwhBiqNuDsFhdTz/fu7ZecmX2S4Z/uosMoXfnGMcrl8dNNktKVGsHFkwHkfFMYtYeV6l4vw==",
-      "dev": true,
-      "dependencies": {
         "@sap-ux/annotation-converter": "0.9.10",
-        "@sap-ux/fiori-annotation-api": "0.3.4",
-        "@sap-ux/project-access": "1.28.10",
+        "@sap-ux/fiori-annotation-api": "0.3.6",
+        "@sap-ux/project-access": "1.29.0",
         "@sap-ux/vocabularies-types": "0.11.7",
         "@xmldom/xmldom": "0.8.10",
         "ejs": "3.1.10",
@@ -4368,30 +4330,12 @@
         "node": ">=18.x"
       }
     },
-    "node_modules/@sap-ux/fe-fpm-writer/node_modules/@sap-ux/project-access": {
-      "version": "1.28.10",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.10.tgz",
-      "integrity": "sha512-UB7zHjj6XBiy9NEenBXkHzCX+i1GpV/XjXdWYiSmWPvbToBprNI84orsslQLWWJhuifZzw7+87Uf5ujDLabVGw==",
-      "dev": true,
-      "dependencies": {
-        "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/ui5-config": "0.26.0",
-        "fast-xml-parser": "4.4.1",
-        "findit2": "2.2.3",
-        "json-parse-even-better-errors": "3.0.2",
-        "mem-fs": "2.1.0",
-        "mem-fs-editor": "9.4.0",
-        "semver": "7.5.4"
-      },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
     "node_modules/@sap-ux/fe-fpm-writer/node_modules/@sap-ux/vocabularies-types": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@sap-ux/vocabularies-types/-/vocabularies-types-0.11.7.tgz",
       "integrity": "sha512-rqRhmPW97dQ8K6nYjL1aP0a4THsUSGK6F5LSOOkSkyTQrBOGu5LNdqi90V2EYKSdIARTvgOnaz1mU+nmkzrsOA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.x"
       }
@@ -4401,25 +4345,27 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/feature-toggle/-/feature-toggle-0.2.3.tgz",
       "integrity": "sha512-2pE6Fd5ldJgIr/HF5y/Qwkj86OFykSA4nckb/Cy4fwqPPCAO4adupnLLJ1KVe2O5iwxY488Mfjc4uqRaaoRT5w==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.x"
       }
     },
     "node_modules/@sap-ux/fiori-annotation-api": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@sap-ux/fiori-annotation-api/-/fiori-annotation-api-0.3.4.tgz",
-      "integrity": "sha512-k4pIjlOPxLpU+B/WKBl/cwLDmZlo+G6gdhBC2Q4pi0naDNcBM51DLUpSHjWH1yI0SQQg0D35oWQ5jUO/ELhcHA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@sap-ux/fiori-annotation-api/-/fiori-annotation-api-0.3.6.tgz",
+      "integrity": "sha512-7aPT5M4RAbt1nt9Rv5PGJ2QBeuEnsMhadceyUR/lWTWksGUkFf/tLpHdWGsRjZC/bOZVnmyTM8zU3uph5aaUxQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/annotation-converter": "0.9.10",
-        "@sap-ux/cds-annotation-parser": "0.2.4",
-        "@sap-ux/cds-odata-annotation-converter": "0.3.9",
+        "@sap-ux/cds-annotation-parser": "0.2.5",
+        "@sap-ux/cds-odata-annotation-converter": "0.3.10",
         "@sap-ux/logger": "0.6.0",
         "@sap-ux/odata-annotation-core": "0.2.2",
         "@sap-ux/odata-annotation-core-types": "0.4.2",
         "@sap-ux/odata-entity-model": "0.3.1",
-        "@sap-ux/odata-vocabularies": "0.4.4",
-        "@sap-ux/project-access": "1.28.10",
+        "@sap-ux/odata-vocabularies": "0.4.5",
+        "@sap-ux/project-access": "1.29.0",
         "@sap-ux/vocabularies-types": "0.11.7",
         "@sap-ux/xml-odata-annotation-converter": "0.3.2",
         "@sap/ux-cds-compiler-facade": "1.15.1",
@@ -4430,43 +4376,26 @@
         "vscode-languageserver-textdocument": "1.0.8"
       }
     },
-    "node_modules/@sap-ux/fiori-annotation-api/node_modules/@sap-ux/project-access": {
-      "version": "1.28.10",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.10.tgz",
-      "integrity": "sha512-UB7zHjj6XBiy9NEenBXkHzCX+i1GpV/XjXdWYiSmWPvbToBprNI84orsslQLWWJhuifZzw7+87Uf5ujDLabVGw==",
-      "dev": true,
-      "dependencies": {
-        "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/ui5-config": "0.26.0",
-        "fast-xml-parser": "4.4.1",
-        "findit2": "2.2.3",
-        "json-parse-even-better-errors": "3.0.2",
-        "mem-fs": "2.1.0",
-        "mem-fs-editor": "9.4.0",
-        "semver": "7.5.4"
-      },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
     "node_modules/@sap-ux/fiori-annotation-api/node_modules/@sap-ux/vocabularies-types": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@sap-ux/vocabularies-types/-/vocabularies-types-0.11.7.tgz",
       "integrity": "sha512-rqRhmPW97dQ8K6nYjL1aP0a4THsUSGK6F5LSOOkSkyTQrBOGu5LNdqi90V2EYKSdIARTvgOnaz1mU+nmkzrsOA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.x"
       }
     },
     "node_modules/@sap-ux/fiori-generator-shared": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/@sap-ux/fiori-generator-shared/-/fiori-generator-shared-0.7.18.tgz",
-      "integrity": "sha512-pcTbob+ZI8IWL/aeC3+BWz4enVqIpBAUPtqNgAN1sP5e/XrbxuOiVfdIioOpZShDd6GBAAJAhbjFEHYuOSmeUA==",
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/@sap-ux/fiori-generator-shared/-/fiori-generator-shared-0.7.19.tgz",
+      "integrity": "sha512-6Dv53pyZCfTy7xwlruk8rARpn7bTse65iWUO41C7JNUddegxJWnXJBkK0w+yITv6T7QbOjvNSh4PkjJFhEnZzg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/btp-utils": "0.17.2",
-        "@sap-ux/project-access": "1.28.10",
-        "@sap-ux/telemetry": "0.5.50",
+        "@sap-ux/project-access": "1.29.0",
+        "@sap-ux/telemetry": "0.5.51",
         "@vscode-logging/logger": "2.0.0",
         "i18next": "20.6.1",
         "logform": "2.4.0",
@@ -4484,27 +4413,9 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@sap-ux/fiori-generator-shared/node_modules/@sap-ux/project-access": {
-      "version": "1.28.10",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.10.tgz",
-      "integrity": "sha512-UB7zHjj6XBiy9NEenBXkHzCX+i1GpV/XjXdWYiSmWPvbToBprNI84orsslQLWWJhuifZzw7+87Uf5ujDLabVGw==",
-      "dev": true,
-      "dependencies": {
-        "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/ui5-config": "0.26.0",
-        "fast-xml-parser": "4.4.1",
-        "findit2": "2.2.3",
-        "json-parse-even-better-errors": "3.0.2",
-        "mem-fs": "2.1.0",
-        "mem-fs-editor": "9.4.0",
-        "semver": "7.5.4"
-      },
-      "engines": {
-        "node": ">=18.x"
       }
     },
     "node_modules/@sap-ux/fiori-generator-shared/node_modules/i18next": {
@@ -4512,6 +4423,7 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
       "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
@@ -4521,6 +4433,7 @@
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
       "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.5.0",
         "fecha": "^4.2.0",
@@ -4530,10 +4443,11 @@
       }
     },
     "node_modules/@sap-ux/guided-answers-helper": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@sap-ux/guided-answers-helper/-/guided-answers-helper-0.2.0.tgz",
-      "integrity": "sha512-VHXM2TxDO6dArV2d8/GCLU0IasecBHbWCU85sVSsNeq4F7/aHfQA9L7seyTd6UrD7D/BGlXWQK+1mc8AvLNsbA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@sap-ux/guided-answers-helper/-/guided-answers-helper-0.2.1.tgz",
+      "integrity": "sha512-ueJTuRiw/ehIZHGMLJNGjwootA509np9QvtIGTVsrVyFT+umAwE3+3izbr9wSLPi90QygcHeL+PnACYee4N11g==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.x"
       }
@@ -4561,17 +4475,18 @@
       "license": "MIT"
     },
     "node_modules/@sap-ux/inquirer-common": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@sap-ux/inquirer-common/-/inquirer-common-0.6.3.tgz",
-      "integrity": "sha512-LiafEH+JDh/K1Q+L2xwZfv63BVTbUeQpKKsUBItEXFNmGKCGTTuYguhc92jO1hyxiQGNmZpXwUjBTabuFSg7ZQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@sap-ux/inquirer-common/-/inquirer-common-0.6.5.tgz",
+      "integrity": "sha512-iId62WFUrbaYixNNoCDc5QxWAyg/w16H0xtYbb47jBgydRGn1CS+iDA6MuLoYAknWVsKPBAb4GaPymZEtWnJIQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/btp-utils": "0.17.2",
         "@sap-ux/feature-toggle": "0.2.3",
-        "@sap-ux/fiori-generator-shared": "0.7.18",
-        "@sap-ux/guided-answers-helper": "0.2.0",
+        "@sap-ux/fiori-generator-shared": "0.7.19",
+        "@sap-ux/guided-answers-helper": "0.2.1",
         "@sap-ux/logger": "0.6.0",
-        "@sap-ux/telemetry": "0.5.50",
+        "@sap-ux/telemetry": "0.5.51",
         "@sap-ux/ui5-info": "0.8.3",
         "@sap/cf-tools": "3.2.2",
         "axios": "1.7.4",
@@ -4592,6 +4507,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4603,6 +4519,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4612,6 +4529,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -4641,6 +4559,7 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5"
       }
@@ -4662,10 +4581,11 @@
       }
     },
     "node_modules/@sap-ux/mockserver-config-writer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@sap-ux/mockserver-config-writer/-/mockserver-config-writer-0.7.0.tgz",
-      "integrity": "sha512-QCgMPk2npWtNtVQKnXvg8V7yOuDXSg1Z0238NeQBvYUGwwmQOkwC/C2TrssJgTHRCjHRgB2vfYcjPraP0bzt5A==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sap-ux/mockserver-config-writer/-/mockserver-config-writer-0.7.1.tgz",
+      "integrity": "sha512-gR2knDsja38P2Iq7arCIFaKsZ6jmhqsBJ0P5C9+ylpYOrm8DJ0G7XlT5rJfME+nNGhvvley6cDQnqIRbRXH8hQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/ui5-config": "0.26.0",
         "i18next": "20.6.1",
@@ -4681,6 +4601,7 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
       "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
@@ -4690,6 +4611,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/odata-annotation-core/-/odata-annotation-core-0.2.2.tgz",
       "integrity": "sha512-v9FLhG82cHjsYo82SvX8CT3lhnr6VO3Unk46e9e7lyIyOefP/kPKCmOLnhhL0wjn/pMatq/9b5rEYYlvC2rHzg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/odata-annotation-core-types": "0.4.2",
         "@sap-ux/text-document-utils": "0.2.0"
@@ -4700,6 +4622,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/odata-annotation-core-types/-/odata-annotation-core-types-0.4.2.tgz",
       "integrity": "sha512-NKfYr7qkO73Ptynw8exHWw3HVJByQWWlqmDGrjv/iRCf1V4jZaWC8/n8pDFvQAU3YYjdjG6HslLKfBmC1G9WXA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/text-document-utils": "0.2.0"
       }
@@ -4708,15 +4631,17 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@sap-ux/odata-entity-model/-/odata-entity-model-0.3.1.tgz",
       "integrity": "sha512-mHyprQ26uRezlkTPrtHHRZFO/hWYnJcZkxGMftZZ0FLEZpzg5diO5sUgCsZZu6Qg3iVOS5+lPWaNmpPXhsGgqA==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sap-ux/odata-service-writer": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@sap-ux/odata-service-writer/-/odata-service-writer-0.25.2.tgz",
-      "integrity": "sha512-J2/y+I2PV1FR0qW/8gdBYc6+jmT5k8HtcK4GMhIwSA/JQTsiBjAnAPJlXlSrSIANcwkkj96wrZhJNQUPnz8Zmw==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@sap-ux/odata-service-writer/-/odata-service-writer-0.25.3.tgz",
+      "integrity": "sha512-25u8p4FD3W8ERgvYWRX+NI/nRq8IOaTQCTpALoam3u57/aQ+SGCbCVeiwxX8JKlMtvVg/bkUkmqLvHahVMFQRA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sap-ux/mockserver-config-writer": "0.7.0",
+        "@sap-ux/mockserver-config-writer": "0.7.1",
         "@sap-ux/ui5-config": "0.26.0",
         "ejs": "3.1.10",
         "fast-xml-parser": "4.4.1",
@@ -4735,31 +4660,34 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
       "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
     },
     "node_modules/@sap-ux/odata-vocabularies": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@sap-ux/odata-vocabularies/-/odata-vocabularies-0.4.4.tgz",
-      "integrity": "sha512-WdEp7WSRwX9ITlvC6WHpCOCGj+LvNZeZQ+5arnBh4lwWRI9cVS+go+OEciroMhPKTHM1I9tLPaTmsmxUHDwSMw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@sap-ux/odata-vocabularies/-/odata-vocabularies-0.4.5.tgz",
+      "integrity": "sha512-fobkGh5GPg7wPC69110/rCNv67wz0kBtqH7aGYjqDldubWQTmGQjX5vwtTndeoRaBbhUnApYhHqfExPLbemcXQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/odata-annotation-core-types": "0.4.2"
       }
     },
     "node_modules/@sap-ux/preview-middleware": {
-      "version": "0.16.166",
-      "resolved": "https://registry.npmjs.org/@sap-ux/preview-middleware/-/preview-middleware-0.16.166.tgz",
-      "integrity": "sha512-QCtEOL98C3mjM9WUJ5ooE7lDWpuAMpg5dkGImxfuHTHu2IzkSItzmUBpioTjkVryqR24f5G8/WuLYGlAewrZgQ==",
+      "version": "0.16.174",
+      "resolved": "https://registry.npmjs.org/@sap-ux/preview-middleware/-/preview-middleware-0.16.174.tgz",
+      "integrity": "sha512-Z+/+wT2U2/ktrxNPuBbbUlvZH16+sYt5q8WcUoJhQRg4CgwQg84S9Q53kaPviJBfb2iZNw93dRYQOzaSdEv+gQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sap-ux/adp-tooling": "0.12.108",
+        "@sap-ux/adp-tooling": "0.12.112",
         "@sap-ux/btp-utils": "0.17.2",
         "@sap-ux/control-property-editor-sources": "npm:@sap-ux/control-property-editor@0.5.32",
         "@sap-ux/feature-toggle": "0.2.3",
         "@sap-ux/logger": "0.6.0",
-        "@sap-ux/project-access": "1.28.10",
+        "@sap-ux/project-access": "1.29.0",
         "ejs": "3.1.10",
         "mem-fs": "2.1.0",
         "mem-fs-editor": "9.4.0"
@@ -4771,32 +4699,12 @@
         "express": "4"
       }
     },
-    "node_modules/@sap-ux/preview-middleware/node_modules/@sap-ux/project-access": {
-      "version": "1.28.10",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.10.tgz",
-      "integrity": "sha512-UB7zHjj6XBiy9NEenBXkHzCX+i1GpV/XjXdWYiSmWPvbToBprNI84orsslQLWWJhuifZzw7+87Uf5ujDLabVGw==",
-      "dev": true,
-      "dependencies": {
-        "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/ui5-config": "0.26.0",
-        "fast-xml-parser": "4.4.1",
-        "findit2": "2.2.3",
-        "json-parse-even-better-errors": "3.0.2",
-        "mem-fs": "2.1.0",
-        "mem-fs-editor": "9.4.0",
-        "semver": "7.5.4"
-      },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
     "node_modules/@sap-ux/project-access": {
-      "version": "1.28.8",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.8.tgz",
-      "integrity": "sha512-O97/bldVr3DAG4OGS9jYY/Uz78sC0wiNm/RDXzU4wKMgBgk8m0ENoRdaE/gtEBbXJ68jrSInqCC/Pp6nQdyLdw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.29.0.tgz",
+      "integrity": "sha512-h7ENAIoQ7/OCr16aqJ3GXlnFDOPgrODupPNzCoxjT4qB0Ce3/lPtJ8mYFSN6Wb50HdgyDvMy76knxL/gzWW60Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@sap-ux/i18n": "0.2.0",
         "@sap-ux/ui5-config": "0.26.0",
@@ -4816,6 +4724,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/project-input-validator/-/project-input-validator-0.3.4.tgz",
       "integrity": "sha512-aQY/rh55T2Rj9lVw3766qwpbgauwsM0u7LsoayDvnoIUUBm85hCtDOaNzyyF4HoAVHlVCdAy1hQitcrcK3ZWVg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "i18next": "23.5.1",
         "validate-npm-package-name": "5.0.0"
@@ -4843,6 +4752,7 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.22.5"
       }
@@ -4852,6 +4762,7 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
       "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "builtins": "^5.0.0"
       },
@@ -4864,6 +4775,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/store/-/store-1.0.0.tgz",
       "integrity": "sha512-0HBiX2Ob/qOcsW7RFIPu1HMZkwYTEtfG4eMV3pSBQmmlJYsTAngD4Brf4y2SOhT0YjzVF4dMKvFn56WXcftH1Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/logger": "0.6.0",
         "i18next": "20.6.1",
@@ -4883,6 +4795,7 @@
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-20.6.1.tgz",
       "integrity": "sha512-yCMYTMEJ9ihCwEQQ3phLo7I/Pwycf8uAx+sRHwwk5U9Aui/IZYgQRyMqXafQOw5QQ7DM1Z+WyEXWIqSuJHhG2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
@@ -4891,15 +4804,17 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-1.2.0.tgz",
       "integrity": "sha512-pUx3AcgXCbur0jpFA7U67Z2RJflAcIi698Y8VL+phdOqUchahxriV3Cs+M6UkPNQSS/zPEzWLfdJ8EgjB7HVxg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sap-ux/system-access": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/@sap-ux/system-access/-/system-access-0.5.25.tgz",
-      "integrity": "sha512-Cclg7q9ghAofVjfSbptL5kfPgie3IU4NlYWklMvIUFl/ctG/xtFXgp0SQBlGGSUw2sBGMh6HM0ANj/AFNUqs7g==",
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/@sap-ux/system-access/-/system-access-0.5.26.tgz",
+      "integrity": "sha512-ran+BdJoLorTYiX2UhKFp94LUtCgn3QRDf35tu6wCEB3KAi3AZ3jv6KHOYFV/ipxwXeBtovHZebRkD+Oo+i42w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@sap-ux/axios-extension": "1.18.0",
+        "@sap-ux/axios-extension": "1.18.1",
         "@sap-ux/btp-utils": "0.17.2",
         "@sap-ux/logger": "0.6.0",
         "@sap-ux/store": "1.0.0",
@@ -4910,14 +4825,15 @@
       }
     },
     "node_modules/@sap-ux/telemetry": {
-      "version": "0.5.50",
-      "resolved": "https://registry.npmjs.org/@sap-ux/telemetry/-/telemetry-0.5.50.tgz",
-      "integrity": "sha512-G/5m/apBdoT7POrnDsPjXUYd6KTvRlnrm9SqthGpjcIgQTkuNtsGxzIQq4M0BUhiFWW3Op731Fy+11tJfyb4mA==",
+      "version": "0.5.51",
+      "resolved": "https://registry.npmjs.org/@sap-ux/telemetry/-/telemetry-0.5.51.tgz",
+      "integrity": "sha512-hpOUXySYHF+yYClFn8ZDXoSqpzen3dgmzVwS0wgufiBzFw/13lOICvbE9v4QbrOviihPwmfJPsU4jSeeiMlrXQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/btp-utils": "0.17.2",
         "@sap-ux/logger": "0.6.0",
-        "@sap-ux/project-access": "1.28.10",
+        "@sap-ux/project-access": "1.29.0",
         "@sap-ux/store": "1.0.0",
         "@sap-ux/ui5-config": "0.26.0",
         "applicationinsights": "2.9.2",
@@ -4929,30 +4845,12 @@
         "node": ">=18.x"
       }
     },
-    "node_modules/@sap-ux/telemetry/node_modules/@sap-ux/project-access": {
-      "version": "1.28.10",
-      "resolved": "https://registry.npmjs.org/@sap-ux/project-access/-/project-access-1.28.10.tgz",
-      "integrity": "sha512-UB7zHjj6XBiy9NEenBXkHzCX+i1GpV/XjXdWYiSmWPvbToBprNI84orsslQLWWJhuifZzw7+87Uf5ujDLabVGw==",
-      "dev": true,
-      "dependencies": {
-        "@sap-ux/i18n": "0.2.0",
-        "@sap-ux/ui5-config": "0.26.0",
-        "fast-xml-parser": "4.4.1",
-        "findit2": "2.2.3",
-        "json-parse-even-better-errors": "3.0.2",
-        "mem-fs": "2.1.0",
-        "mem-fs-editor": "9.4.0",
-        "semver": "7.5.4"
-      },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
     "node_modules/@sap-ux/telemetry/node_modules/axios": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4964,6 +4862,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
       "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 14"
       }
@@ -5001,6 +4900,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/ui5-info/-/ui5-info-0.8.3.tgz",
       "integrity": "sha512-q3nm/UYKxKf9Uuj9HEGy1C1KMPNP+1P6EHKCNPeHeV3SPinb4jssGdubrYT0Os0CUe2uXbO2/SVP8ePWtJlo6g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/logger": "0.6.0",
         "axios": "1.7.4",
@@ -5015,6 +4915,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -5036,6 +4937,7 @@
       "resolved": "https://registry.npmjs.org/@sap-ux/xml-odata-annotation-converter/-/xml-odata-annotation-converter-0.3.2.tgz",
       "integrity": "sha512-9y4PfsOo0uA/BARtnb1S9jxrUscQJRUrjEfJFoNmwLGeO62D/QUTOX7BC8qiyedB4kVnpbdoxB3bMWVWOn6zCw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@sap-ux/odata-annotation-core": "0.2.2"
       }
@@ -5065,9 +4967,9 @@
       }
     },
     "node_modules/@sap/cds": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-8.6.1.tgz",
-      "integrity": "sha512-JYHRrGs6Tgle5Vmj/o3BaQkOBVcroweOrXhhiUVH6twISy+Yi2cWZdTr0EFFEt94FI1dVqvrVnEM67jEjOQImQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-8.7.1.tgz",
+      "integrity": "sha512-hTS4tqRcF9EQ8bUGu0z1fHBCtQuQuPbsEHbqJxzOWOVgc3leFoSckB0z0zBR4LTzZuv/RmpiNS7M0AKibrmnQg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@sap/cds-compiler": ">=5.1",
@@ -5084,18 +4986,22 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "express": ">=4"
+        "express": "^4",
+        "tar": "^7"
       },
       "peerDependenciesMeta": {
         "express": {
+          "optional": true
+        },
+        "tar": {
           "optional": true
         }
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-5.6.0.tgz",
-      "integrity": "sha512-MYhAQNkSQPwi16q738edpHP9JcVH8gunm15+02nQu1Rz59PQDcj7GcWqyb4EGQklKRyMUg/5J4zXKaH1RxKqgA==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-5.7.4.tgz",
+      "integrity": "sha512-LbfmiaqFBzclBDCsOvnRKQgGJTT+QC1nPWpsGxMblvAIkaJ3qzgWQnpKzuDknitZlv5T68vSu79HUl3lThYjug==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "antlr4": "4.9.3"
@@ -5110,9 +5016,9 @@
       }
     },
     "node_modules/@sap/cds-fiori": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@sap/cds-fiori/-/cds-fiori-1.2.8.tgz",
-      "integrity": "sha512-UXvsd4pGxnrxMBDO3HWLHFYhkVIsz3F15ePrAqHpeUKXw42ToCFFu+QJTbhKtONKlxoW1DVDobga4K1dvSyzrw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-fiori/-/cds-fiori-1.3.0.tgz",
+      "integrity": "sha512-PEppgJyc3SO0df5zP2OZG41UKLdsowQLwcsLUSFPzn56MlbFdzaRhO1qXaMhPlQ+bIo19aLOZcAZa9ewkSwS0w==",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "@sap/cds": ">=7.6",
@@ -5139,6 +5045,7 @@
       "resolved": "https://registry.npmjs.org/@sap/cf-tools/-/cf-tools-3.2.2.tgz",
       "integrity": "sha512-hlz3KiHbKrQJdydacVbpBSufoiNDU7YEE5MnvTUOm0FabI+L+fp+b5RZqwSsurUtTm8RJzrHSUVXTqztyW13oA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "comment-json": "4.2.5",
         "lodash": "4.17.21",
@@ -5151,6 +5058,7 @@
       "resolved": "https://registry.npmjs.org/@sap/ux-cds-compiler-facade/-/ux-cds-compiler-facade-1.15.1.tgz",
       "integrity": "sha512-WfKLjNFZa6hfXu7+JUmvbCn110lLyddmBN4n1tpV7sH279bue8JF48ZPSqe70+Gric6YdY7jRoiVEALWRkzZ7w==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "engines": {
         "node": ">=18.16.0"
       },
@@ -5161,12 +5069,13 @@
       }
     },
     "node_modules/@sap/ux-specification": {
-      "version": "1.124.8",
-      "resolved": "https://registry.npmjs.org/@sap/ux-specification/-/ux-specification-1.124.8.tgz",
-      "integrity": "sha512-Zlk5Mmwf3VdMiJlpCFIJsMJvj0OMGp94zPbeb2vQCGb9Y6K2afCG4XvnmnTZ5gPncTe2K2hx/38OUhXwFCitVw==",
+      "version": "1.124.9",
+      "resolved": "https://registry.npmjs.org/@sap/ux-specification/-/ux-specification-1.124.9.tgz",
+      "integrity": "sha512-/x+4BYynUU9PVle7ntK96xMdlZKRB4p2OzZ7qXDMWFzJsIjk1FWNnTp+LruddWbu4zSbHTKtQICyRtoXs2EhtQ==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@sap-ux/fe-fpm-writer": "0.31.23",
+        "@sap-ux/fe-fpm-writer": "0.31.25",
         "@sap-ux/vocabularies-types": "0.12.0"
       },
       "engines": {
@@ -5175,12 +5084,13 @@
       }
     },
     "node_modules/@sap/ux-ui5-tooling": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@sap/ux-ui5-tooling/-/ux-ui5-tooling-1.16.2.tgz",
-      "integrity": "sha512-B/UBXu/mG3TVXLxpyNjA72tCiISRpKQd4zHO0YaIgvS0hefpJkTDdhcJxTglLSdBf43D4KhU6pY0RGR20TZQQw==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@sap/ux-ui5-tooling/-/ux-ui5-tooling-1.16.3.tgz",
+      "integrity": "sha512-VEuEo9fPKGurK3WyyINcT+d5O8QsAaRh1Yj2rkW/e5ZMJJ0B0TE2sjsy3ihR/PmMJZxiiR2eO2hzSh7mtBcS6Q==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@sap-ux/preview-middleware": "0.16.166",
+        "@sap-ux/preview-middleware": "0.16.174",
         "@ui5/fs": "3.0.4",
         "connect-livereload": "0.6.1",
         "debug": "4.3.7",
@@ -5385,13 +5295,13 @@
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-3.0.0.tgz",
-      "integrity": "sha512-XDUYX56iMPAn/cdgh/DTJxz5RWmqKV4pwvUAEKEWJl+HzKdCd/24wUa9JYNMlDSCb7SUHAdtksxYX779Nne/Zg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-3.1.0.tgz",
+      "integrity": "sha512-Mm1E3/CmDDCz3nDhFKTuYdB47EdRFRQMOE/EAbiG1MJW77/w1b3P7Qx7JSrVJs8PfwOLOVcKQCHErIwCTyPbag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.2"
+        "@sigstore/protobuf-specs": "^0.4.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -5408,9 +5318,9 @@
       }
     },
     "node_modules/@sigstore/protobuf-specs": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.3.3.tgz",
-      "integrity": "sha512-RpacQhBlwpBWd7KEJsRKcBQalbV28fvkxwTOJIqhIuDysMMaJW47V4OqW30iJB9uRpqOSxxEAQFdr8tTattReQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.4.0.tgz",
+      "integrity": "sha512-o09cLSIq9EKyRXwryWDOJagkml9XgQCoCSRjHOnHLnvsivaW7Qznzz6yjfV7PHJHhIvyp8OH7OX8w0Dc5bQK7A==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5418,16 +5328,16 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-3.0.0.tgz",
-      "integrity": "sha512-UjhDMQOkyDoktpXoc5YPJpJK6IooF2gayAr5LvXI4EL7O0vd58okgfRcxuaH+YTdhvb5aa1Q9f+WJ0c2sVuYIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-3.1.0.tgz",
+      "integrity": "sha512-knzjmaOHOov1Ur7N/z4B1oPqZ0QX5geUfhrVaqVlu+hl0EAoL4o+l0MSULINcD5GCWe3Z0+YJO8ues6vFlW0Yw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "make-fetch-happen": "^14.0.1",
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "make-fetch-happen": "^14.0.2",
         "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1"
       },
@@ -5436,13 +5346,13 @@
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-3.0.0.tgz",
-      "integrity": "sha512-9Xxy/8U5OFJu7s+OsHzI96IX/OzjF/zj0BSSaWhgJgTqtlBhQIV2xdrQI5qxLD7+CWWDepadnXAxzaZ3u9cvRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-3.1.0.tgz",
+      "integrity": "sha512-suVMQEA+sKdOz5hwP9qNcEjX6B45R+hFFr4LAWzbRc5O+U2IInwvay/bpG5a4s+qR35P/JK/PiKiRGjfuLy1IA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.2",
+        "@sigstore/protobuf-specs": "^0.4.0",
         "tuf-js": "^3.0.1"
       },
       "engines": {
@@ -5450,15 +5360,15 @@
       }
     },
     "node_modules/@sigstore/verify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-2.0.0.tgz",
-      "integrity": "sha512-Ggtq2GsJuxFNUvQzLoXqRwS4ceRfLAJnrIHUDrzAD0GgnOhwujJkKkxM/s5Bako07c3WtAs/sZo5PJq7VHjeDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/verify/-/verify-2.1.0.tgz",
+      "integrity": "sha512-kAAM06ca4CzhvjIZdONAL9+MLppW3K48wOFy1TbuaWFW/OMfl8JuTgW0Bm02JB1WJGT/ET2eqav0KTEKmxqkIA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2"
+        "@sigstore/protobuf-specs": "^0.4.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -5526,6 +5436,7 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -5644,13 +5555,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/cors": {
       "version": "2.8.17",
@@ -5821,9 +5725,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
-      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5896,7 +5800,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/sizzle": {
       "version": "2.3.9",
@@ -5955,21 +5860,21 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.22.0.tgz",
-      "integrity": "sha512-4Uta6REnz/xEJMvwf72wdUnC3rr4jAQf5jnTkeRQ9b6soxLxhDEbS/pfMPoJLDfFPNVRdryqWUIV/2GZzDJFZw==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.23.0.tgz",
+      "integrity": "sha512-vBz65tJgRrA1Q5gWlRfvoH+w943dq9K1p1yDBY2pc+a1nbBLZp7fB9+Hk8DaALUbzjqlMfgaqlVPT1REJdkt/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/type-utils": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
+        "@typescript-eslint/scope-manager": "8.23.0",
+        "@typescript-eslint/type-utils": "8.23.0",
+        "@typescript-eslint/utils": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5984,147 +5889,17 @@
         "typescript": ">=4.8.4 <5.8.0"
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz",
-      "integrity": "sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.22.0.tgz",
-      "integrity": "sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz",
-      "integrity": "sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.22.0.tgz",
-      "integrity": "sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz",
-      "integrity": "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
-      "integrity": "sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.23.0.tgz",
+      "integrity": "sha512-h2lUByouOXFAlMec2mILeELUbME5SZRN/7R9Cw2RD2lRQQY08MWMM+PmVVKKJNK1aIwqTo9t/0CvOxwPbRIE2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.20.0",
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/typescript-estree": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
+        "@typescript-eslint/scope-manager": "8.23.0",
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/typescript-estree": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6140,14 +5915,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.20.0.tgz",
-      "integrity": "sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.23.0.tgz",
+      "integrity": "sha512-OGqo7+dXHqI7Hfm+WqkZjKjsiRtFUQHPdGMXzk5mYXhJUedO7e/Y7i8AK3MyLMgZR93TX4bIzYrfyVjLC+0VSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0"
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6158,16 +5933,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.22.0.tgz",
-      "integrity": "sha512-NzE3aB62fDEaGjaAYZE4LH7I1MUwHooQ98Byq0G0y3kkibPJQIXVUspzlFOmOfHhiDLwKzMlWxaNv+/qcZurJA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.23.0.tgz",
+      "integrity": "sha512-iIuLdYpQWZKbiH+RkCGc6iu+VwscP5rCtQ1lyQ7TYuKLrcZoeJVpcLiG8DliXVkUxirW/PWlmS+d6yD51L9jvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.22.0",
-        "@typescript-eslint/utils": "8.22.0",
+        "@typescript-eslint/typescript-estree": "8.23.0",
+        "@typescript-eslint/utils": "8.23.0",
         "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6179,142 +5954,12 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.22.0.tgz",
-      "integrity": "sha512-/lwVV0UYgkj7wPSw0o8URy6YI64QmcOdwHuGuxWIYznO6d45ER0wXUbksr9pYdViAofpUCNJx/tAzNukgvaaiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.22.0.tgz",
-      "integrity": "sha512-0S4M4baNzp612zwpD4YOieP3VowOARgK2EkN/GBn95hpyF8E2fbMT55sRHWBq+Huaqk3b3XK+rxxlM8sPgGM6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.22.0.tgz",
-      "integrity": "sha512-SJX99NAS2ugGOzpyhMza/tX+zDwjvwAtQFLsBo3GQxiGcvaKlqGBkmZ+Y1IdiSi9h4Q0Lr5ey+Cp9CGWNY/F/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/visitor-keys": "8.22.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.22.0.tgz",
-      "integrity": "sha512-T8oc1MbF8L+Bk2msAvCUzjxVB2Z2f+vXYfcucE2wOmYs7ZUwco5Ep0fYZw8quNwOiw9K8GYVL+Kgc2pETNTLOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.22.0",
-        "@typescript-eslint/types": "8.22.0",
-        "@typescript-eslint/typescript-estree": "8.22.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.22.0.tgz",
-      "integrity": "sha512-AWpYAXnUgvLNabGTy3uBylkgZoosva/miNd1I8Bz3SjotmQPbVqhO4Cczo8AsZ44XVErEBPr/CRSgaj8sG7g0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.22.0",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
-      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
-      "integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.23.0.tgz",
+      "integrity": "sha512-1sK4ILJbCmZOTt9k4vkoulT6/y5CHJ1qUYxqpF1K/DBAd8+ZUL4LlSCxOssuH5m4rUaaN0uS0HlVPvd45zjduQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6326,20 +5971,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
-      "integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.23.0.tgz",
+      "integrity": "sha512-LcqzfipsB8RTvH8FX24W4UUFk1bl+0yTOf9ZA08XngFwMg4Kj8A+9hwz8Cr/ZS4KwHrmo9PJiLZkOt49vPnuvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/visitor-keys": "8.23.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
-        "ts-api-utils": "^2.0.0"
+        "ts-api-utils": "^2.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6369,9 +6014,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6382,16 +6027,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.20.0.tgz",
-      "integrity": "sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.23.0.tgz",
+      "integrity": "sha512-uB/+PSo6Exu02b5ZEiVtmY6RVYO7YU5xqgzTIVZwTHvvK3HsL8tZZHFaTLFtRG3CsV4A5mhOv+NZx5BlhXPyIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.20.0",
-        "@typescript-eslint/types": "8.20.0",
-        "@typescript-eslint/typescript-estree": "8.20.0"
+        "@typescript-eslint/scope-manager": "8.23.0",
+        "@typescript-eslint/types": "8.23.0",
+        "@typescript-eslint/typescript-estree": "8.23.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6406,13 +6051,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
-      "integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.23.0.tgz",
+      "integrity": "sha512-oWWhcWDLwDfu++BGTZcmXWqpwtkwb5o7fxUIGksMQQDSdPW9prsSnfIOZMlsj4vBOSrcnjIUZMiIjODgGosFhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/types": "8.23.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -6452,9 +6097,9 @@
       }
     },
     "node_modules/@ui5/builder/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12630,9 +12275,9 @@
       }
     },
     "node_modules/@ui5/project/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12679,6 +12324,7 @@
       "resolved": "https://registry.npmjs.org/@vscode-logging/logger/-/logger-2.0.0.tgz",
       "integrity": "sha512-m5AsHLqNyC8OYmpXf4bA5Hm2gSrJcc2L7KUfA8wMH/GFDexeNSTi/O6rDdWFawxLZg3uQGETDx8xyMfMqCDp+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@vscode-logging/types": "^2.0.0",
         "fast-safe-stringify": "2.1.1",
@@ -12696,6 +12342,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -12710,6 +12357,7 @@
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.6.0.tgz",
       "integrity": "sha512-wbBA9PbPAHxKiygo7ub7BYRiKxms0tpfU2ljtWzb3SjRjv5yl6Ozuy/TkXf00HTAt+Uylo3gSkNwzc4ME0wiIg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "logform": "^2.3.2",
         "readable-stream": "^3.6.0",
@@ -12723,13 +12371,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@vscode-logging/types/-/types-2.0.0.tgz",
       "integrity": "sha512-P42r5SPYeJKgMDYb5Ez9rjPlpnGEZ1eDFVjT0azxueaJ65iE259hpROmvSPUd80HAALn9/59L+CgcGLmwZcCmg==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@xml-tools/ast": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@xml-tools/ast/-/ast-5.0.5.tgz",
       "integrity": "sha512-avvzTOvGplCx9JSKdsTe3vK+ACvsHy2HxVfkcfIqPzu+kF5CT4rw5aUVzs0tJF4cnDyMRVkSyVxR07X0Px8gPA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@xml-tools/common": "^0.1.6",
         "@xml-tools/parser": "^1.0.11",
@@ -12741,6 +12391,7 @@
       "resolved": "https://registry.npmjs.org/@xml-tools/common/-/common-0.1.6.tgz",
       "integrity": "sha512-7aVZeEYccs1KI/Asd6KKnrB4dTAWXTkjRMjG40ApGEUp5NpfQIvWLEBvMv85Koj2lbSpagcAERwDy9qMsfWGdA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.17.21"
       }
@@ -12750,6 +12401,7 @@
       "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
       "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "chevrotain": "7.1.1"
       }
@@ -12777,19 +12429,20 @@
       "integrity": "sha512-cE8rlBADL48wmiQr+fdQdxczW4wLsmv5BQa03QepKiydBBE7TLrG2Anx/F4uZ+sVIZQuN95SHvwkt8VZaTzuyw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "EPL-2.0",
       "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
+      "integrity": "sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/accepts": {
@@ -12832,6 +12485,7 @@
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -12851,6 +12505,7 @@
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
       "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0"
       }
@@ -12922,7 +12577,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12935,7 +12590,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -12975,6 +12630,7 @@
       "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.9.2.tgz",
       "integrity": "sha512-wlDiD7v0BQNM8oNzsf9C836R5ze25u+CuCEZsbA5xMIXYYBxkqkWE/mo9GFJM7rsKaiGqpxEwWmePHKD2Lwy2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "^1.5.0",
         "@azure/core-rest-pipeline": "1.10.1",
@@ -13087,6 +12743,7 @@
       "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
       "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "stack-chain": "^1.3.7"
       },
@@ -13099,6 +12756,7 @@
       "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
       "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^5.3.0",
         "shimmer": "^1.1.0"
@@ -13112,6 +12770,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -13394,7 +13053,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -13444,9 +13103,9 @@
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.4.tgz",
-      "integrity": "sha512-G6i3A74FjNq4nVrrSTUz5h3vgXzBJnjmWAVlBWaZETkgu+LgKd7AiyOml3EDJY1AHlIbBHKDXE+TUT53Ff8OaA==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -13508,9 +13167,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.7.2.tgz",
-      "integrity": "sha512-10a57cHVDmfNQS4jrZ9AH2t+2ekzYh5Rhbcnb4ytpmYweoLdogDmyTt5D+hLiY9b44Mx9foowb/4iXBTO2yP3Q==",
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.8.1.tgz",
+      "integrity": "sha512-9BxNaBkblMjhJW8sMRZxnxVTRgbRmssZW0Oxc1MPBTfiR+WW21e2Mk4qu8CzrcZb1LwPCnFsfDEzq+SNcBU8eg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13742,7 +13401,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13864,6 +13523,7 @@
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
       "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.0.0"
       }
@@ -13970,9 +13630,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001692",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+      "version": "1.0.30001697",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
+      "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ==",
       "dev": true,
       "funding": [
         {
@@ -14023,9 +13683,9 @@
       }
     },
     "node_modules/cds-plugin-ui5/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -14108,7 +13768,8 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/check-error": {
       "version": "1.0.3",
@@ -14172,6 +13833,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
       "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "regexp-to-ast": "0.5.0"
       }
@@ -14218,21 +13880,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-1.1.0.tgz",
-      "integrity": "sha512-HislCEczCuamWm3+55Lig9XKmMF13K+BGKum9rwtDAzgUAHT4h5jNwhDmD4U20VoVUG8ujnv9UZ89qiIf5uF8w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-1.2.0.tgz",
+      "integrity": "sha512-XtdJ1GSN6S3l7tO7F77GhNsw0K367p0IsLYf2yZawCVAKKC3lUvDhPdMVrB2FNhmhfW43QGYbEX3Wg6q0maGwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "mitt": "3.0.1",
-        "zod": "3.24.1"
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -14255,9 +13917,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
-      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -14279,6 +13941,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -14304,6 +13967,7 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -14316,6 +13980,7 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 10"
       }
@@ -14420,6 +14085,7 @@
       "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
       "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "async-hook-jl": "^1.7.6",
         "emitter-listener": "^1.0.1",
@@ -14434,6 +14100,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -14471,7 +14138,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14484,7 +14151,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -14839,6 +14506,7 @@
       "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "async-listener": "^0.6.0",
         "emitter-listener": "^1.1.1"
@@ -14954,7 +14622,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -14969,14 +14637,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -15148,6 +14816,7 @@
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -15160,6 +14829,7 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -15230,7 +14900,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/detect-content-type/-/detect-content-type-1.2.0.tgz",
       "integrity": "sha512-YCBxuqJLY9rMxV44Ict2kNgjYFN3v1dnsn6sJvd6sUwwU1TWP3D+K2dr/S9AF/fio2/RsAKYdRiEOtNoRbmiag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.0.3",
@@ -15276,9 +14947,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1380148",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1380148.tgz",
-      "integrity": "sha512-1CJABgqLxbYxVI+uJY/UDUHJtJ0KZTSjNYJYKqd9FRoXT33WDakDHNxRapMEgzeJ/C3rcs01+avshMnPmKQbvA==",
+      "version": "0.0.1402036",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1402036.tgz",
+      "integrity": "sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -15294,6 +14965,7 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
       "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -15303,6 +14975,7 @@
       "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.8.tgz",
       "integrity": "sha512-HmSm9hXxSPxA9BaLGY98QU1zsdjeCk113KjAYGPCen1ZP6mhVaTPzHd6UYv5r21DnWANi+f+NyPOHruGT9jpqQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "diagnostic-channel": "*"
       }
@@ -15469,7 +15142,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
@@ -15495,9 +15168,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.82",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.82.tgz",
-      "integrity": "sha512-Zq16uk1hfQhyGx5GpwPAYDwddJuSGhtRhgOA2mCxANYaDT79nAeGnaXogMGng4KqLaJUVnOnuL0+TDop9nLOiA==",
+      "version": "1.5.92",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.92.tgz",
+      "integrity": "sha512-BeHgmNobs05N1HMmMZ7YIuHfYBGlq/UmvlsTgg+fsbFs9xVMj+xJHFg19GN04+9Q+r8Xnh9LXqaYIyEWElnNgQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -15506,6 +15179,7 @@
       "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "shimmer": "^1.2.0"
       }
@@ -15527,7 +15201,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -15609,13 +15283,12 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz",
-      "integrity": "sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==",
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/cookie": "^0.4.1",
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
@@ -15758,6 +15431,7 @@
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
       }
@@ -15781,9 +15455,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.0.tgz",
-      "integrity": "sha512-Ujz8Al/KfOVR7fkaghAB1WvnLsdYxHDWmfoi2vlA2jZWRg31XhIC1a4B+/I24muD8iSbHxJ1JkrfqmWb65P/Mw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -15928,9 +15602,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
-      "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
+      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15939,7 +15613,7 @@
         "@eslint/config-array": "^0.19.0",
         "@eslint/core": "^0.10.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.18.0",
+        "@eslint/js": "9.19.0",
         "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -15985,102 +15659,6 @@
         "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-plugin-fiori-custom": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-fiori-custom/-/eslint-plugin-fiori-custom-2.6.7.tgz",
-      "integrity": "sha512-mQdL1TA0sk9VprMA8t0bLUuuzcdLq8JLfiCkqcm+eMbUb2zgIIHEGdVxCwdWVY+ZHn99UG1C86GcataX3ShJOg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@babel/core": "7.20.12",
-        "@babel/eslint-parser": "7.19.1",
-        "lodash": "4.17.21",
-        "requireindex": "1.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.5"
-      }
-    },
-    "node_modules/eslint-plugin-fiori-custom/node_modules/@babel/core": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
-      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.7",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.20.11",
-        "@babel/helpers": "^7.20.7",
-        "@babel/parser": "^7.20.7",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.12",
-        "@babel/types": "^7.20.7",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/eslint-plugin-fiori-custom/node_modules/@babel/eslint-parser": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.19.1.tgz",
-      "integrity": "sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
-        "eslint-visitor-keys": "^2.1.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-fiori-custom/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-fiori-custom/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-plugin-fiori-custom/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -16421,6 +15999,7 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -16529,7 +16108,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
@@ -16555,9 +16135,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-      "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -16812,7 +16392,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -16870,6 +16450,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -17045,9 +16626,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
+      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17083,7 +16664,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -17117,7 +16698,7 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -17521,6 +17102,7 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
       }
@@ -17611,9 +17193,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17632,6 +17214,7 @@
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.12.0.tgz",
       "integrity": "sha512-yAgSE7GmtRcu4ZUSFX/4v69UGXwugFFSdIQJ14LHPOPPQrWv8Y7O9PHsw8Ovk7bKCLe4sjXMbZFqGFcLHpZ89w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-attributes": "^1.9.5",
@@ -17725,6 +17308,7 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
       "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -17751,6 +17335,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -17760,6 +17345,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -17769,6 +17355,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -17784,6 +17371,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -17796,6 +17384,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -17914,7 +17503,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -17965,6 +17554,7 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -18237,7 +17827,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -19352,9 +18942,9 @@
       }
     },
     "node_modules/karma-ui5-transpile": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/karma-ui5-transpile/-/karma-ui5-transpile-3.5.3.tgz",
-      "integrity": "sha512-QvuQWFg/jX/OilWr1J4aWR3x43bdNv88hUBAGwXVe5N6dTidX+ZG73MwlG1c/M90ZCo5HrDhYhOkRIxzwyw6FQ==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/karma-ui5-transpile/-/karma-ui5-transpile-3.5.5.tgz",
+      "integrity": "sha512-T6qERXVV//3OueO29OtVST/8b7nBa1EtJ2+Bm/+z1zmitKXgh+nQ0g7G40Ms8e6Zm+COrZe3UVo5fZSrByXf6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -19777,6 +19367,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -19793,6 +19384,7 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -19849,7 +19441,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/macos-release": {
@@ -19857,6 +19449,7 @@
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.1.tgz",
       "integrity": "sha512-DXqXhEM7gW59OjZO8NIjBCz9AQ1BEMrfiOAl4AYByHCtVHRF4KoGNO8mqQeM8lRCtQe/UnJ4imO/d2HdkKsd+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -20248,7 +19841,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -20388,7 +19981,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.1.tgz",
       "integrity": "sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.4",
@@ -20429,7 +20022,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
       "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -20485,12 +20079,13 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "dev": true,
       "license": "MIT"
     },
@@ -20522,9 +20117,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.72.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.72.0.tgz",
-      "integrity": "sha512-a28z9xAQXvDh40lVCknWCP5zYTZt6Av8HZqZ63U5OWxTcP20e3oOIy8yHkYfctQM2adR8ru1GxWCkS0gS+WYKA==",
+      "version": "3.74.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
+      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20630,13 +20225,13 @@
       }
     },
     "node_modules/nopt": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.0.0.tgz",
-      "integrity": "sha512-1L/fTJ4UmV/lUxT2Uf006pfZKTvAgCF+chz+0OgBHO8u2Z67pE7AaAUUj7CJy0lXqHmymUvGFt6NE9R3HER0yw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^2.0.0"
+        "abbrev": "^3.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
@@ -20646,18 +20241,31 @@
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.0.tgz",
-      "integrity": "sha512-k6U0gKRIuNCTkwHGZqblCfLfBRh+w1vI6tBo+IeJwq2M8FUiOqhX7GH+GArQGScA7azd1WfyRCvxoXDO3hQDIA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^8.0.0",
+        "hosted-git-info": "^7.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -20818,9 +20426,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -20909,6 +20517,7 @@
       "resolved": "https://registry.npmjs.org/open/-/open-7.0.3.tgz",
       "integrity": "sha512-sP2ru2v0P290WFfv49Ap8MF6PkzGNnGlAwHweB4WR4mr5d2d0woiCluUeJ218w7/+PmoBy9JmYgD5A4mLcWOFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -20950,6 +20559,7 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -20973,6 +20583,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -20982,6 +20593,7 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -20994,6 +20606,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -21006,6 +20619,7 @@
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-4.0.1.tgz",
       "integrity": "sha512-xl9MAoU97MH1Xt5K9ERft2YfCAoaO6msy1OBA0ozxEC0x0TmIoE6K3QvgJMMZA9yKGLmHXNY/YZoDbiGDj4zYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "macos-release": "^2.5.0",
         "windows-release": "^4.0.0"
@@ -21120,7 +20734,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pacote": {
@@ -21515,7 +21129,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -21532,7 +21146,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -21585,7 +21199,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -21701,6 +21316,7 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -21731,9 +21347,9 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21742,7 +21358,7 @@
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
+        "napi-build-utils": "^2.0.0",
         "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
@@ -21771,7 +21387,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/prettify-xml/-/prettify-xml-1.2.0.tgz",
       "integrity": "sha512-kuoTbmC+QQUfx45PrdkVzJqrNEp2lhK++WGyiqBx6JrCvZUQDgeYjdV3h53n7p+37s1Iwx6GjAQ7fcIgD8kkLQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-data": {
       "version": "0.40.0",
@@ -21888,6 +21505,7 @@
       "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.3.0.tgz",
       "integrity": "sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mkdirp": "^1.0.4"
       },
@@ -22001,18 +21619,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.1.1.tgz",
-      "integrity": "sha512-fuhceZ5HZuDXVuaMIRxUuDHfCJLmK0pXh8FlzVQ0/+OApStevxZhU5kAVeYFOEqeCF5OoAyZjcWbdQK27xW/9A==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.2.0.tgz",
+      "integrity": "sha512-z8vv7zPEgrilIbOo3WNvM+2mXMnyM9f4z6zdrB88Fzeuo43Oupmjrzk3EpuvuCtyK0A7Lsllfx7Z+4BvEEGJcQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.7.0",
-        "chromium-bidi": "1.1.0",
+        "@puppeteer/browsers": "2.7.1",
+        "chromium-bidi": "1.2.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1380148",
-        "puppeteer-core": "24.1.1",
+        "devtools-protocol": "0.0.1402036",
+        "puppeteer-core": "24.2.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -22023,16 +21641,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.1.1.tgz",
-      "integrity": "sha512-7FF3gq6bpIsbq3I8mfbodXh3DCzXagoz3l2eGv1cXooYU4g0P4mcHQVHuBD4iSZPXNg8WjzlP5kmRwK9UvwF0A==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.2.0.tgz",
+      "integrity": "sha512-e4A4/xqWdd4kcE6QVHYhJ+Qlx/+XpgjP4d8OwBx0DJoY/nkIRhSgYmKQnv7+XSs1ofBstalt+XPGrkaz4FoXOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.7.0",
-        "chromium-bidi": "1.1.0",
+        "@puppeteer/browsers": "2.7.1",
+        "chromium-bidi": "1.2.0",
         "debug": "^4.4.0",
-        "devtools-protocol": "0.0.1380148",
+        "devtools-protocol": "0.0.1402036",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.0"
       },
@@ -22123,13 +21741,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/qunit": {
@@ -22246,9 +21857,9 @@
       }
     },
     "node_modules/read-package-up/node_modules/type-fest": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
-      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
+      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -22278,34 +21889,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
-      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^10.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
-      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/read-pkg/node_modules/parse-json": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
@@ -22325,9 +21908,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "4.32.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
-      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
+      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -22377,7 +21960,8 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -22420,7 +22004,8 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
       "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexpu-core": {
       "version": "6.2.0",
@@ -22559,10 +22144,11 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.4.0.tgz",
-      "integrity": "sha512-X34iHADNbNDfr6OTStIAHWSAvvKQRYgLO6duASaVf7J2VA3lvmNYboAHOuLC2huav1IwgZJtyEcJCKVzFxOSMQ==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.0.tgz",
+      "integrity": "sha512-/Tvpny/RVVicqlYTKwt/GtpZRsPG1CmJNhxVKGz+Sy/4MONfXCVNK69MFgGKdUt0/324q3ClI2dICcPgISrC8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
         "module-details-from-path": "^1.0.3",
@@ -22570,16 +22156,6 @@
       },
       "engines": {
         "node": ">=8.6.0"
-      }
-    },
-    "node_modules/requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.5"
       }
     },
     "node_modules/requires-port": {
@@ -22678,6 +22254,7 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -22690,7 +22267,8 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/retry": {
       "version": "0.12.0",
@@ -22724,7 +22302,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
@@ -22777,6 +22355,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -22810,6 +22389,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -22873,6 +22453,7 @@
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
       "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "dev": true,
+      "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
@@ -23041,7 +22622,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -23054,7 +22635,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23064,7 +22645,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -23142,7 +22724,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -23152,18 +22734,18 @@
       }
     },
     "node_modules/sigstore": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-3.0.0.tgz",
-      "integrity": "sha512-PHMifhh3EN4loMcHCz6l3v/luzgT3za+9f8subGgeMNjbJjzH4Ij/YoX3Gvu+kaouJRIlVdTHHCREADYf+ZteA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sigstore/-/sigstore-3.1.0.tgz",
+      "integrity": "sha512-ZpzWAFHIFqyFE56dXqgX/DkDRZdz+rRcjoIk/RQU4IX0wiCv1l8S7ZrXDHcCc+uaf+6o7w3h2l3g6GYG5TKN9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/bundle": "^3.1.0",
         "@sigstore/core": "^2.0.0",
-        "@sigstore/protobuf-specs": "^0.3.2",
-        "@sigstore/sign": "^3.0.0",
-        "@sigstore/tuf": "^3.0.0",
-        "@sigstore/verify": "^2.0.0"
+        "@sigstore/protobuf-specs": "^0.4.0",
+        "@sigstore/sign": "^3.1.0",
+        "@sigstore/tuf": "^3.1.0",
+        "@sigstore/verify": "^2.1.0"
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -23465,9 +23047,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -23542,13 +23124,15 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stack-generator": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
       "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
       }
@@ -23590,13 +23174,15 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stacktrace-gps": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
       "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "source-map": "0.5.6",
         "stackframe": "^1.3.4"
@@ -23607,6 +23193,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23616,6 +23203,7 @@
       "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
       "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^2.0.6",
         "stack-generator": "^2.0.5",
@@ -23682,14 +23270,13 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.1.tgz",
-      "integrity": "sha512-PhP9wUnFLa+91CPy3N6tiQsK+gnYyUNuk15S3YG/zjYE7RuPeCjJngqnzpC31ow0lzBHQ+QGO4cNJnd0djYUsw==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
@@ -23754,7 +23341,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -23770,7 +23357,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -23785,7 +23372,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23795,7 +23382,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -23808,7 +23395,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23818,7 +23405,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -23831,7 +23418,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -23848,7 +23435,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -23861,7 +23448,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23977,7 +23564,7 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
       "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -24047,7 +23634,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -24060,9 +23647,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
-      "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
+      "version": "5.38.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.38.0.tgz",
+      "integrity": "sha512-a4GD5R1TjEeuCT6ZRiYMHmIf7okbCPEuhQET8bczV6FrQMMlFXA1n+G0KKjdlFCm3TEHV77GxfZB3vZSUQGFpg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -24277,14 +23864,15 @@
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dev": true,
+      "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
-      "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
+      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24344,9 +23932,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -24492,69 +24080,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.20.0.tgz",
-      "integrity": "sha512-Kxz2QRFsgbWj6Xcftlw3Dd154b3cEPFqQC+qMZrMypSijPd4UanKKvoKDrJ4o8AIfZFKAF+7sMaEIR8mTElozA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.23.0.tgz",
+      "integrity": "sha512-/LBRo3HrXr5LxmrdYSOCvoAMm7p2jNizNfbIpCgvG4HMsnoprRUOce/+8VJ9BDYWW68rqIENE/haVLWPeFZBVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.20.0",
-        "@typescript-eslint/parser": "8.20.0",
-        "@typescript-eslint/utils": "8.20.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.20.0.tgz",
-      "integrity": "sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.20.0",
-        "@typescript-eslint/type-utils": "8.20.0",
-        "@typescript-eslint/utils": "8.20.0",
-        "@typescript-eslint/visitor-keys": "8.20.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.8.0"
-      }
-    },
-    "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.20.0.tgz",
-      "integrity": "sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.20.0",
-        "@typescript-eslint/utils": "8.20.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.0.0"
+        "@typescript-eslint/eslint-plugin": "8.23.0",
+        "@typescript-eslint/parser": "8.23.0",
+        "@typescript-eslint/utils": "8.23.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -24635,9 +24169,9 @@
       }
     },
     "node_modules/ui5-task-zipper": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ui5-task-zipper/-/ui5-task-zipper-3.3.1.tgz",
-      "integrity": "sha512-Ym0sb2zThoNIGyWFv3ZQvYl+EYZhts+fLHwnd0bxjLo/pS1h9LGznrwwLZpti+PAQE+99sXtNPQlKGdruoXiBg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ui5-task-zipper/-/ui5-task-zipper-3.3.3.tgz",
+      "integrity": "sha512-zMmZ/5KuD0yR0rrfKW5hdCT53gOkd/OhLcmZZHKKg+/wMepbeADMdIwyu1pqB65MxtdsoaVhv4V5QvRpBpyuRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24645,9 +24179,9 @@
       }
     },
     "node_modules/ui5-tooling-transpile": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/ui5-tooling-transpile/-/ui5-tooling-transpile-3.5.3.tgz",
-      "integrity": "sha512-G5Yns+MZbCTn6ICdC5gb8eYfm664LwlZpe0ylxLXymxUj7VIwol/JS4DsgxhHTZM+TERlyKbnrXHKpdBJ5mNCw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/ui5-tooling-transpile/-/ui5-tooling-transpile-3.6.1.tgz",
+      "integrity": "sha512-LAsx52E8aC6sT0gIioJH3136SzaTcbxUixbzjw0/NZYJnf/dvrzkPiJzn8nxJC+XtdtDw0woIjK5Auhy9rn2xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24675,17 +24209,6 @@
       "integrity": "sha512-GWoGjF3Dhbr2AL/olobzkqDa3R3Sg/M98vCIamUfdb9vtgJy88x/nOQtsOBQ94bwwSu/qJgac9NgqI3KB1pWxw==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
     },
     "node_modules/underscore": {
       "version": "1.13.7",
@@ -24900,6 +24423,7 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
       "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -24912,13 +24436,15 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
-      "dev": true
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -24945,6 +24471,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -25043,7 +24570,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
       "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.2",
@@ -25084,6 +24612,7 @@
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
       }
@@ -25183,6 +24712,7 @@
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-4.0.0.tgz",
       "integrity": "sha512-OxmV4wzDKB1x7AZaZgXMVsdJ1qER1ed83ZrTYd5Bwq2HfJVg3DJS8nqlAG4sMoJ7mu8cuRmLEYyU13BKwctRAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "execa": "^4.0.2"
       },
@@ -25198,6 +24728,7 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
       "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "get-stream": "^5.0.0",
@@ -25221,6 +24752,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -25236,6 +24768,7 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.12.0"
       }
@@ -25244,7 +24777,8 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/winston": {
       "version": "3.11.0",
@@ -25335,7 +24869,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -25354,7 +24888,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -25372,7 +24906,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25382,7 +24916,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -25395,7 +24929,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25408,14 +24942,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -25494,6 +25028,7 @@
       "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-2.6.1.tgz",
       "integrity": "sha512-dOiGwoqm8y22QdTNI7A+N03tyVfBlQ0/oehAzxIZtwnFAHGeSlrfjF73YQvzSsa/Kt6+YZasKsrdu6OIpuBggw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xml-parser-xo": "^3.2.0"
       },
@@ -25506,6 +25041,7 @@
       "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-3.2.0.tgz",
       "integrity": "sha512-8LRU6cq+d7mVsoDaMhnkkt3CTtAs4153p49fRo+HIB3I1FD1o5CeXRjRH29sQevIfVJIcPjKSsPU/+Ujhq09Rg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -25574,7 +25110,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
- Brings an old pinned version of babel through `eslint-plugin-fiori-custom`.
- Is bound to old ESLint 8.