### PR TITLE
Run cds-typer before cds watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ npm i -g @sap/cds-dk
 In the root folder of your project, run
 ```
 npm ci
-npx cds-typer "*"
 cds watch
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "lint": "npx eslint .",
     "start": "cds-serve",
+    "before:cds-watch": "cds-typer \"*\"",
     "build:ui": "npm run build --prefix app/travel_analytics && npm run build --prefix app/travel_processor",
     "test": "jest",
     "test:mocha": "npx -y mocha",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "build:ui": "npm run build --prefix app/travel_analytics && npm run build --prefix app/travel_processor",
     "test": "jest",
     "test:mocha": "npx -y mocha",
-    "travel-processor": "cds-tsx watch --open sap.fe.cap.travel/index.html?sap-ui-xx-viewCache=false",
-    "travel-analytics": "cds-tsx watch --open sap.fe.cap.travel_analytics/index.html?sap-ui-xx-viewCache=false"
+    "travel-processor": "cds watch --open sap.fe.cap.travel/index.html?sap-ui-xx-viewCache=false",
+    "travel-analytics": "cds watch --open sap.fe.cap.travel_analytics/index.html?sap-ui-xx-viewCache=false"
   },
   "dependencies": {
     "@cap-js/hana": "^1",


### PR DESCRIPTION
Run cds-typer via `before:cds-watch` npm script, removing the need for a manual `cds-typer "*"` after cloning (possible since cds-dk 8.8.0).

Also use cds watch instead of cds-tsx watch in npm scripts (possible since cds-dk 8.6.0).