### PR TITLE
feat: Add public contact form application

### DIFF
--- a/app/contact_form/package.json
+++ b/app/contact_form/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "contact-form-ui",
+  "version": "1.0.0",
+  "description": "Contact Form UI",
+  "scripts": {
+    "build": "ui5 build --all --clean-dest --dest dist",
+    "start": "ui5 serve --open index.html"
+  },
+  "devDependencies": {
+    "@ui5/cli": "^3.0.0"
+  },
+  "ui5": {
+    "dependencies": [
+      "@sap/ui5-builder-webide-extension",
+      "ui5-middlewares-livereload"
+    ]
+  }
+}

--- a/app/contact_form/webapp/Component.js
+++ b/app/contact_form/webapp/Component.js
@@ -1,0 +1,24 @@
+sap.ui.define([
+    "sap/ui/core/UIComponent",
+    "sap/ui/Device",
+    "company/contactform/app/model/models" // This file won't exist yet, but it's standard. Can be created empty or omitted for now.
+], function (UIComponent, Device, models) {
+    "use strict";
+
+    return UIComponent.extend("company.contactform.app.Component", {
+        metadata: {
+            manifest: "json"
+        },
+
+        init: function () {
+            // call the base component's init function
+            UIComponent.prototype.init.apply(this, arguments);
+
+            // enable routing
+            this.getRouter().initialize();
+
+            // set the device model - this line can be removed if models.js is not created
+            // this.setModel(models.createDeviceModel(), "device");
+        }
+    });
+});

--- a/app/contact_form/webapp/controller/ContactForm.controller.js
+++ b/app/contact_form/webapp/controller/ContactForm.controller.js
@@ -1,0 +1,70 @@
+sap.ui.define([
+    "sap/ui/core/mvc/Controller",
+    "sap/m/MessageToast",
+    "sap/ui/model/json/JSONModel"
+], function (Controller, MessageToast, JSONModel) {
+    "use strict";
+
+    return Controller.extend("company.contactform.app.controller.ContactForm", {
+        onInit: function () {
+            // Create a new JSON model for the form data
+            this.getView().setModel(new JSONModel({
+                name: "",
+                email: "",
+                company: "",
+                phone: "",
+                message: ""
+            }), "formModel");
+        },
+
+        _validateForm: function() {
+            var oFormModel = this.getView().getModel("formModel");
+            var oData = oFormModel.getData();
+            var bValid = true;
+            var oResourceBundle = this.getView().getModel("i18n").getResourceBundle();
+
+            if (!oData.name || oData.name.trim() === "") {
+                MessageToast.show(oResourceBundle.getText("validationNameMandatory"));
+                bValid = false;
+            }
+            if (!oData.email || !/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(oData.email)) {
+                 MessageToast.show(oResourceBundle.getText("validationEmailInvalid"));
+                bValid = false;
+            }
+            if (!oData.message || oData.message.trim() === "") {
+                 MessageToast.show(oResourceBundle.getText("validationMessageMandatory"));
+                bValid = false;
+            }
+            return bValid;
+        },
+
+        onSubmit: function () {
+            if (!this._validateForm()) {
+                return;
+            }
+
+            var oFormModel = this.getView().getModel("formModel");
+            var oData = oFormModel.getData();
+            var oODataModel = this.getView().getModel(); // Default OData model
+            var oResourceBundle = this.getView().getModel("i18n").getResourceBundle();
+
+            oODataModel.create("/ContactRequests", oData, {
+                success: function () {
+                    MessageToast.show(oResourceBundle.getText("submitSuccess"));
+                    // Clear form
+                    oFormModel.setData({
+                        name: "",
+                        email: "",
+                        company: "",
+                        phone: "",
+                        message: ""
+                    });
+                }.bind(this),
+                error: function (oError) {
+                    MessageToast.show(oResourceBundle.getText("submitError"));
+                    console.error(oError);
+                }.bind(this)
+            });
+        }
+    });
+});

--- a/app/contact_form/webapp/i18n/i18n.properties
+++ b/app/contact_form/webapp/i18n/i18n.properties
@@ -1,0 +1,15 @@
+appTitle=Contact Us
+appDescription=A simple form to get in touch.
+
+contactFormTitle=Contact Form
+formName=Name
+formEmail=Email Address
+formCompany=Company (Optional)
+formPhone=Phone Number (Optional)
+formMessage=Message
+submitButtonText=Submit
+submitSuccess=Thank you! Your message has been sent.
+submitError=Error sending message. Please try again.
+validationNameMandatory=Please enter your name.
+validationEmailInvalid=Please enter a valid email address.
+validationMessageMandatory=Please enter a message.

--- a/app/contact_form/webapp/index.html
+++ b/app/contact_form/webapp/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact Us</title>
+    <script
+        id="sap-ui-bootstrap"
+        src="https://sdk.openui5.org/resources/sap-ui-core.js"
+        data-sap-ui-theme="sap_horizon"
+        data-sap-ui-resourceroots='{
+            "company.contactform.app": "./"
+        }'
+        data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
+        data-sap-ui-compatVersion="edge"
+        data-sap-ui-async="true"
+        data-sap-ui-frameOptions="trusted">
+    </script>
+</head>
+<body class="sapUiBody">
+    <div data-sap-ui-component data-name="company.contactform.app" data-id="container" data-settings='{"id" : "app"}'></div>
+</body>
+</html>

--- a/app/contact_form/webapp/manifest.json
+++ b/app/contact_form/webapp/manifest.json
@@ -1,0 +1,104 @@
+{
+  "_version": "1.12.0",
+  "sap.app": {
+    "id": "company.contactform.app",
+    "type": "application",
+    "i18n": "i18n/i18n.properties",
+    "applicationVersion": {
+      "version": "1.0.0"
+    },
+    "title": "{{appTitle}}",
+    "description": "{{appDescription}}",
+    "dataSources": {
+      "contactService": {
+        "uri": "/public/contact/",
+        "type": "OData",
+        "settings": {
+          "odataVersion": "4.0"
+        }
+      }
+    }
+  },
+  "sap.ui": {
+    "technology": "UI5",
+    "icons": {
+      "icon": "",
+      "favIcon": "",
+      "phone": "",
+      "phone@2": "",
+      "tablet": "",
+      "tablet@2": ""
+    },
+    "deviceTypes": {
+      "desktop": true,
+      "tablet": true,
+      "phone": true
+    }
+  },
+  "sap.ui5": {
+    "flexEnabled": false,
+    "rootView": {
+      "viewName": "company.contactform.app.view.ContactForm",
+      "type": "XML",
+      "async": true,
+      "id": "ContactFormView"
+    },
+    "dependencies": {
+      "minUI5Version": "1.108.0",
+      "libs": {
+        "sap.m": {},
+        "sap.ui.core": {},
+        "sap.ui.layout": {}
+      }
+    },
+    "contentDensities": {
+      "compact": true,
+      "cozy": true
+    },
+    "models": {
+      "i18n": {
+        "type": "sap.ui.model.resource.ResourceModel",
+        "settings": {
+          "bundleName": "company.contactform.app.i18n.i18n"
+        }
+      },
+      "": {
+        "dataSource": "contactService",
+        "preload": true,
+        "settings": {
+          "synchronizationMode": "None",
+          "operationMode": "Server",
+          "autoExpandSelect": true,
+          "earlyRequests": true
+        }
+      }
+    },
+    "routing": {
+      "config": {
+        "routerClass": "sap.m.routing.Router",
+        "viewType": "XML",
+        "async": true,
+        "viewPath": "company.contactform.app.view",
+        "controlAggregation": "pages",
+        "controlId": "app",
+        "clearControlAggregation": false
+      },
+      "routes": [
+        {
+          "name": "RouteContactForm",
+          "pattern": ":?query:",
+          "target": ["TargetContactForm"]
+        }
+      ],
+      "targets": {
+        "TargetContactForm": {
+          "viewType": "XML",
+          "transition": "slide",
+          "clearControlAggregation": false,
+          "viewId": "ContactForm",
+          "viewName": "ContactForm"
+        }
+      }
+    }
+  }
+}

--- a/app/contact_form/webapp/model/models.js
+++ b/app/contact_form/webapp/model/models.js
@@ -1,0 +1,14 @@
+sap.ui.define([
+    "sap/ui/model/json/JSONModel",
+    "sap/ui/Device"
+], function (JSONModel, Device) {
+    "use strict";
+
+    return {
+        createDeviceModel: function () {
+            var oModel = new JSONModel(Device);
+            oModel.setDefaultBindingMode("OneWay");
+            return oModel;
+        }
+    };
+});

--- a/app/contact_form/webapp/view/ContactForm.view.xml
+++ b/app/contact_form/webapp/view/ContactForm.view.xml
@@ -1,0 +1,38 @@
+<mvc:View
+    controllerName="company.contactform.app.controller.ContactForm"
+    xmlns:mvc="sap.ui.core.mvc"
+    xmlns:l="sap.ui.layout"
+    xmlns:f="sap.ui.layout.form"
+    xmlns="sap.m">
+    <Page id="contactFormPage" title="{i18n>contactFormTitle}">
+        <content>
+            <f:SimpleForm id="contactSimpleForm"
+                editable="true"
+                layout="ResponsiveGridLayout"
+                labelSpanXL="3" labelSpanL="3" labelSpanM="12" labelSpanS="12"
+                adjustLabelSpan="false"
+                emptySpanXL="4" emptySpanL="4" emptySpanM="0" emptySpanS="0"
+                columnsXL="1" columnsL="1" columnsM="1"
+                singleContainerFullSize="false">
+                <f:content>
+                    <Label text="{i18n>formName}" required="true"/>
+                    <Input id="nameInput" value="{formModel>/name}" required="true"/>
+                    <Label text="{i18n>formEmail}" required="true"/>
+                    <Input id="emailInput" type="Email" value="{formModel>/email}" required="true"/>
+                    <Label text="{i18n>formCompany}"/>
+                    <Input id="companyInput" value="{formModel>/company}"/>
+                    <Label text="{i18n>formPhone}"/>
+                    <Input id="phoneInput" type="Tel" value="{formModel>/phone}"/>
+                    <Label text="{i18n>formMessage}" required="true"/>
+                    <TextArea id="messageInput" value="{formModel>/message}" rows="4" required="true"/>
+                </f:content>
+            </f:SimpleForm>
+        </content>
+        <footer>
+            <Toolbar>
+                <ToolbarSpacer/>
+                <Button id="submitButton" text="{i18n>submitButtonText}" type="Emphasized" press=".onSubmit"/>
+            </Toolbar>
+        </footer>
+    </Page>
+</mvc:View>

--- a/app/contact_form/webapp/xs-app.json
+++ b/app/contact_form/webapp/xs-app.json
@@ -1,0 +1,31 @@
+{
+  "welcomeFile": "/index.html",
+  "authenticationMethod": "none",
+  "routes": [
+    {
+      "source": "^/resources/(.*)$",
+      "target": "/resources/$1",
+      "authenticationType": "none",
+      "destination": "ui5"
+    },
+    {
+      "source": "^/test-resources/(.*)$",
+      "target": "/test-resources/$1",
+      "authenticationType": "none",
+      "destination": "ui5"
+    },
+    {
+      "source": "^/public/contact/(.*)$",
+      "target": "/public/contact/$1",
+      "destination": "sflight-srv",
+      "authenticationType": "none",
+      "csrfProtection": false
+    },
+    {
+      "source": "^/(.*)$",
+      "target": "$1",
+      "service": "html5-apps-repo-rt",
+      "authenticationType": "none"
+    }
+  ]
+}

--- a/db/contact-schema.cds
+++ b/db/contact-schema.cds
@@ -1,0 +1,11 @@
+namespace company.contactform;
+
+using { cuid, managed } from '@sap/cds/common';
+
+entity ContactRequests : cuid, managed {
+  name    : String(100) not null;
+  email   : String(100) not null @(assert.format: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+  company : String(100);
+  phone   : String(50);
+  message : LargeString not null;
+}

--- a/db/schema.cds
+++ b/db/schema.cds
@@ -1,3 +1,4 @@
+using from './contact-schema';
 using { Currency, custom.managed, sap.common.CodeList } from './common';
 using {
   sap.fe.cap.travel.Airline,

--- a/mta.yaml
+++ b/mta.yaml
@@ -66,6 +66,10 @@ modules:
           artifacts:
             - travel-analytics.zip
           target-path: app/
+        - name: sflight-app-contact-form
+          artifacts:
+            - contact_form.zip # The build result (dist folder) should be zipped as contact_form.zip
+          target-path: app/
 
   # ------------- APPLICATION: TRAVEL PROCESSOR ----------------
   - name: sflight-app-travel-processor
@@ -89,6 +93,19 @@ modules:
       builder: custom
       commands:
         - npm run build
+      supported-platforms: []
+
+  # ------------- APPLICATION: CONTACT FORM ------------------
+  - name: sflight-app-contact-form
+  # ------------------------------------------------------------
+    type: html5
+    path: app/contact_form
+    build-parameters:
+      build-result: dist # The package.json for contact_form UI is set to build into 'dist'
+      builder: custom
+      commands:
+        - npm install # Ensure dependencies are installed
+        - npm run build # This uses ui5 build from app/contact_form/package.json
       supported-platforms: []
 
   # ------------------ DESTINATION CONTENT ---------------------

--- a/srv/contact-service.cds
+++ b/srv/contact-service.cds
@@ -1,0 +1,9 @@
+using { company.contactform as cf } from '../db/contact-schema';
+
+service ContactService @(path:'/public/contact') {
+  @restrict: [
+    { grant: 'WRITE', to: '*' } // Allow anyone to submit the form
+    // No explicit READ grant means it's not publicly readable by default
+  ]
+  entity ContactRequests as projection on cf.ContactRequests;
+}

--- a/srv/contact-service.ts
+++ b/srv/contact-service.ts
@@ -1,0 +1,50 @@
+import cds from '@sap/cds';
+import { ContactRequests } from '#cds-models/company/contactform'; // Adjust if path is different after generation
+
+export class ContactService extends cds.ApplicationService {
+  async init() {
+    this.after('CREATE', 'ContactRequests', async (data: ContactRequests, req: cds.Request) => {
+      console.log('New contact form submission received:');
+      console.log('Name:', data.name);
+      console.log('Email:', data.email);
+      if (data.company) console.log('Company:', data.company);
+      if (data.phone) console.log('Phone:', data.phone);
+      console.log('Message:', data.message);
+      console.log('Created At:', data.createdAt);
+
+      // Placeholder for email sending logic
+      const emailTarget = 'subscriber@company.com';
+      console.log(`TODO: Send email with the above details to ${emailTarget}`);
+
+      // Here you would typically use a library like nodemailer
+      // and configure it with SMTP server details (e.g., from environment variables or a bound service)
+      // Example (conceptual, actual implementation requires nodemailer and config):
+      //
+      // import nodemailer from 'nodemailer';
+      // const transporter = nodemailer.createTransport({
+      //   host: process.env.SMTP_HOST,
+      //   port: process.env.SMTP_PORT,
+      //   secure: false, // true for 465, false for other ports
+      //   auth: {
+      //     user: process.env.SMTP_USER,
+      //     pass: process.env.SMTP_PASS,
+      //   },
+      // });
+      //
+      // try {
+      //   await transporter.sendMail({
+      //     from: '"Contact Form" <noreply@company.com>',
+      //     to: emailTarget,
+      //     subject: 'New Contact Form Submission',
+      //     text: `Name: ${data.name}\nEmail: ${data.email}\nCompany: ${data.company || ''}\nPhone: ${data.phone || ''}\nMessage: ${data.message}`,
+      //     html: `<p>Name: ${data.name}</p><p>Email: ${data.email}</p><p>Company: ${data.company || ''}</p><p>Phone: ${data.phone || ''}</p><p>Message: ${data.message}</p>`,
+      //   });
+      //   console.log('Email sent (simulated).');
+      // } catch (error) {
+      //   console.error('Error sending email (simulated):', error);
+      // }
+    });
+
+    await super.init();
+  }
+}


### PR DESCRIPTION
This commit introduces a new publicly accessible contact form application.

The application consists of:
- A Fiori UI (`app/contact_form`) allowing you to submit your contact details and a message. This UI is configured for public access.
- A CAP service (`srv/contact-service.cds` and `srv/contact-service.ts`) that exposes a `ContactRequests` entity.
  - The service stores submitted form data in the HANA database (via `db/contact-schema.cds`).
  - It includes a placeholder for sending an email notification to subscriber@company.com upon new form submission. Actual email sending requires further SMTP configuration and nodemailer integration.
  - The service endpoint for creating contact requests is publicly accessible.
- Updated MTA (`mta.yaml`) to include the new Fiori application and ensure the service and database schema changes are deployed.
- Configuration files (`xs-app.json` for the UI) were adjusted to enable public access and proper routing to the backend service.