### PR TITLE
Remove `ts-jest` from `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "http-proxy": "^1.18.1",
     "jest": "^30.1.0",
     "qunit": "^2.9.3",
-    "ts-jest": "^29.2.5",
     "tsx": "^4.19.2",
     "typescript-eslint": "^8.12.2"
   },


### PR DESCRIPTION
I don't think this is used any longer and `ts-jest` requires `glob` version 7, which is now deprecated.

This is currently the root cause for installation warnings in `cap/dev`.